### PR TITLE
feat: optimize external models with default database and adjusted scan intervals

### DIFF
--- a/models/external/mainnet/canonical_execution_balance_diffs.sql
+++ b/models/external/mainnet/canonical_execution_balance_diffs.sql
@@ -2,14 +2,21 @@
 database: mainnet
 table: canonical_execution_balance_diffs
 cache:
-  incremental_scan_interval: 30s
+  incremental_scan_interval: 1m
   full_scan_interval: 24h
 ---
 SELECT 
     min(block_number) as min,
     max(block_number) as max
-FROM `{{ .self.database }}`.`{{ .self.table }}`
+-- Use the default database as predicate pushdown does not work with views.
+-- This gives 2-3x the performance.
+-- Once we move the data into the mainnet database, we no longer need this.
+FROM `default`.`{{ .self.table }}`
+WHERE 
+    meta_network_name = 'mainnet'
 {{ if .cache.is_incremental_scan }}
-WHERE block_number <= {{ .cache.previous_min }}
-   OR block_number >= {{ .cache.previous_max }}
+    (
+      block_number <= {{ .cache.previous_min }}
+      OR block_number >= {{ .cache.previous_max }}
+    )
 {{ end }}

--- a/models/external/mainnet/canonical_execution_balance_reads.sql
+++ b/models/external/mainnet/canonical_execution_balance_reads.sql
@@ -2,14 +2,21 @@
 database: mainnet
 table: canonical_execution_balance_reads
 cache:
-  incremental_scan_interval: 30s
+  incremental_scan_interval: 1m
   full_scan_interval: 24h
 ---
 SELECT 
     min(block_number) as min,
     max(block_number) as max
-FROM `{{ .self.database }}`.`{{ .self.table }}`
+-- Use the default database as predicate pushdown does not work with views.
+-- This gives 2-3x the performance.
+-- Once we move the data into the mainnet database, we no longer need this.
+FROM `default`.`{{ .self.table }}`
+WHERE 
+    meta_network_name = 'mainnet'
 {{ if .cache.is_incremental_scan }}
-WHERE block_number <= {{ .cache.previous_min }}
-   OR block_number >= {{ .cache.previous_max }}
+    (
+      block_number <= {{ .cache.previous_min }}
+      OR block_number >= {{ .cache.previous_max }}
+    )
 {{ end }}

--- a/models/external/mainnet/canonical_execution_contracts.sql
+++ b/models/external/mainnet/canonical_execution_contracts.sql
@@ -2,14 +2,21 @@
 database: mainnet
 table: canonical_execution_contracts
 cache:
-  incremental_scan_interval: 30s
+  incremental_scan_interval: 1m
   full_scan_interval: 24h
 ---
 SELECT 
     min(block_number) as min,
     max(block_number) as max
-FROM `{{ .self.database }}`.`{{ .self.table }}`
+-- Use the default database as predicate pushdown does not work with views.
+-- This gives 2-3x the performance.
+-- Once we move the data into the mainnet database, we no longer need this.
+FROM `default`.`{{ .self.table }}`
+WHERE 
+    meta_network_name = 'mainnet'
 {{ if .cache.is_incremental_scan }}
-WHERE block_number <= {{ .cache.previous_min }}
-   OR block_number >= {{ .cache.previous_max }}
+    (
+      block_number <= {{ .cache.previous_min }}
+      OR block_number >= {{ .cache.previous_max }}
+    )
 {{ end }}

--- a/models/external/mainnet/canonical_execution_nonce_reads.sql
+++ b/models/external/mainnet/canonical_execution_nonce_reads.sql
@@ -2,14 +2,21 @@
 database: mainnet
 table: canonical_execution_nonce_reads
 cache:
-  incremental_scan_interval: 30s
+  incremental_scan_interval: 1m
   full_scan_interval: 24h
 ---
 SELECT 
     min(block_number) as min,
     max(block_number) as max
-FROM `{{ .self.database }}`.`{{ .self.table }}`
+-- Use the default database as predicate pushdown does not work with views.
+-- This gives 2-3x the performance.
+-- Once we move the data into the mainnet database, we no longer need this.
+FROM `default`.`{{ .self.table }}`
+WHERE 
+    meta_network_name = 'mainnet'
 {{ if .cache.is_incremental_scan }}
-WHERE block_number <= {{ .cache.previous_min }}
-   OR block_number >= {{ .cache.previous_max }}
+    (
+      block_number <= {{ .cache.previous_min }}
+      OR block_number >= {{ .cache.previous_max }}
+    )
 {{ end }}

--- a/models/external/mainnet/canonical_execution_storage_diffs.sql
+++ b/models/external/mainnet/canonical_execution_storage_diffs.sql
@@ -2,14 +2,21 @@
 database: mainnet
 table: canonical_execution_storage_diffs
 cache:
-  incremental_scan_interval: 30s
+  incremental_scan_interval: 1m
   full_scan_interval: 24h
 ---
 SELECT 
     min(block_number) as min,
     max(block_number) as max
-FROM `{{ .self.database }}`.`{{ .self.table }}`
+-- Use the default database as predicate pushdown does not work with views.
+-- This gives 2-3x the performance.
+-- Once we move the data into the mainnet database, we no longer need this.
+FROM `default`.`{{ .self.table }}`
+WHERE 
+    meta_network_name = 'mainnet'
 {{ if .cache.is_incremental_scan }}
-WHERE block_number <= {{ .cache.previous_min }}
-   OR block_number >= {{ .cache.previous_max }}
+    (
+      block_number <= {{ .cache.previous_min }}
+      OR block_number >= {{ .cache.previous_max }}
+    )
 {{ end }}

--- a/models/external/mainnet/canonical_execution_storage_reads.sql
+++ b/models/external/mainnet/canonical_execution_storage_reads.sql
@@ -2,14 +2,21 @@
 database: mainnet
 table: canonical_execution_storage_reads
 cache:
-  incremental_scan_interval: 30s
+  incremental_scan_interval: 1m
   full_scan_interval: 24h
 ---
 SELECT 
     min(block_number) as min,
     max(block_number) as max
-FROM `{{ .self.database }}`.`{{ .self.table }}`
+-- Use the default database as predicate pushdown does not work with views.
+-- This gives 2-3x the performance.
+-- Once we move the data into the mainnet database, we no longer need this.
+FROM `default`.`{{ .self.table }}`
+WHERE 
+    meta_network_name = 'mainnet'
 {{ if .cache.is_incremental_scan }}
-WHERE block_number <= {{ .cache.previous_min }}
-   OR block_number >= {{ .cache.previous_max }}
+    (
+      block_number <= {{ .cache.previous_min }}
+      OR block_number >= {{ .cache.previous_max }}
+    )
 {{ end }}

--- a/models/transformations/mainnet/intermediate/address/account_first_access.sql
+++ b/models/transformations/mainnet/intermediate/address/account_first_access.sql
@@ -2,11 +2,11 @@
 database: mainnet
 table: int_address__account_first_access
 forwardfill:
-  interval: 1000
-  schedule: "@every 10s"
+  interval: 10
+  schedule: "@every 5m"
 backfill:
   interval: 10000
-  schedule: "@every 10s"
+  schedule: "@every 1m"
 tags:
   - mainnet
   - address

--- a/models/transformations/mainnet/intermediate/address/account_last_access.sql
+++ b/models/transformations/mainnet/intermediate/address/account_last_access.sql
@@ -2,11 +2,11 @@
 database: mainnet
 table: int_address__account_last_access
 forwardfill:
-  interval: 1000
-  schedule: "@every 10s"
+  interval: 10
+  schedule: "@every 5m"
 backfill:
   interval: 10000
-  schedule: "@every 10s"
+  schedule: "@every 1m"
 tags:
   - mainnet
   - address


### PR DESCRIPTION
- Change incremental scan interval from 30s to 1m for all canonical execution models
- Use default database instead of mainnet for 2-3x performance improvement
- Fixes predicate pushdown limitations with views
- Update intermediate address access models accordingly