### PR TITLE
feat: minimal testing framework for SQL transformations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/xatu"]
+	path = vendor/xatu
+	url = https://github.com/ethpandaops/xatu.git

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,41 @@
+version: '3.8'
+
+networks:
+  xatu-test-net:
+    external: true
+    name: xatu_xatu-net
+
+services:
+  cbt-redis-test:
+    image: redis:7-alpine
+    container_name: cbt-redis-test
+    networks:
+      - xatu-test-net
+
+  cbt-migrator:
+    image: migrate/migrate
+    container_name: cbt-migrator-test
+    volumes:
+      - ./migrations:/migrations
+    environment:
+      - CBT_DATABASE_PREFIX=${CBT_DATABASE_PREFIX}
+    command:
+      - "-path=/migrations"
+      - "-database=clickhouse://xatu-clickhouse-01:9000?database=${CBT_DATABASE_PREFIX}mainnet&x-migrations-table=schema_migrations_cbt"
+      - "up"
+    networks:
+      - xatu-test-net
+
+  cbt-engine:
+    image: ethpandaops/cbt:latest
+    container_name: cbt-engine-test
+    volumes:
+      - ./models:/models:ro
+      - ./tests/config/test-config.yaml:/config.yaml:ro
+    command: ["--config", "/config.yaml"]
+    environment:
+      - LOG_LEVEL=debug
+    depends_on:
+      - cbt-redis-test
+    networks:
+      - xatu-test-net

--- a/models/external/mainnet/canonical_beacon_block.test.yaml
+++ b/models/external/mainnet/canonical_beacon_block.test.yaml
@@ -1,0 +1,19 @@
+tests:
+  - name: "validate_canonical_beacon_block_data"
+    data_set: minimal
+    assertions:
+      - query: |
+          SELECT COUNT(*) as total
+          FROM mainnet.canonical_beacon_block
+          WHERE slot BETWEEN 1234567 AND 1234577
+        expected:
+          total: 10
+      
+      - query: |
+          SELECT slot, block_root
+          FROM mainnet.canonical_beacon_block
+          WHERE slot = 1234567
+          LIMIT 1
+        expected:
+          slot: 1234567
+          block_root: "0xabcd..."

--- a/models/transformations/mainnet/intermediate/slot/block_proposer_head.test.yaml
+++ b/models/transformations/mainnet/intermediate/slot/block_proposer_head.test.yaml
@@ -1,0 +1,36 @@
+tests:
+  - name: "validate_block_proposer_mapping"
+    data_set: electra
+    assertions:
+      - query: |
+          SELECT COUNT(*) as total
+          FROM mainnet.int_slot__block_proposer_head
+          WHERE slot BETWEEN 1234567 AND 1234577
+        expected:
+          total: 10
+      
+      - query: |
+          SELECT proposer_validator_index, block_root
+          FROM mainnet.int_slot__block_proposer_head
+          WHERE slot = 1234567
+        expected:
+          proposer_validator_index: 98765
+          block_root: "0xabcd..."
+      
+      - query: |
+          SELECT COUNT(*) as missed_slots
+          FROM mainnet.int_slot__block_proposer_head
+          WHERE slot BETWEEN 1234567 AND 1234577
+            AND block_root IS NULL
+        expected:
+          missed_slots: 2
+
+  - name: "validate_performance_metrics"
+    data_set: minimal
+    assertions:
+      - query: |
+          SELECT AVG(proposer_delay_ms) as avg_delay
+          FROM mainnet.int_slot__block_proposer_head
+          WHERE slot_start_date_time BETWEEN '2024-10-15' AND '2024-10-16'
+        expected:
+          avg_delay: 1234.5

--- a/tests/config/test-config.yaml
+++ b/tests/config/test-config.yaml
@@ -1,0 +1,28 @@
+logging:
+  level: debug
+  format: json
+
+clickhouse:
+  host: xatu-clickhouse-01
+  port: 9000
+  database: mainnet
+  username: default
+  password: ""
+  max_connections: 10
+  connection_timeout: 30s
+
+redis:
+  host: cbt-redis-test
+  port: 6379
+  password: ""
+  db: 0
+  pool_size: 10
+
+engine:
+  workers: 4
+  batch_size: 1000
+  poll_interval: 5s
+  
+models:
+  path: /models
+  watch: false

--- a/tests/data-sets/electra.yaml
+++ b/tests/data-sets/electra.yaml
@@ -1,0 +1,22 @@
+name: electra
+description: "Electra fork data for testing block proposals"
+network: mainnet
+tables:
+  - name: canonical_beacon_block
+    urls:
+      - https://data.ethpandaops.io/xatu/mainnet/databases/default/canonical_beacon_block/2024/10/15.parquet
+      - https://data.ethpandaops.io/xatu/mainnet/databases/default/canonical_beacon_block/2024/10/16.parquet
+    
+  - name: beacon_api_eth_v1_events_block
+    urls:
+      - https://data.ethpandaops.io/xatu/mainnet/databases/default/beacon_api_eth_v1_events_block/2024/10/15.parquet
+
+  - name: beacon_api_eth_v1_proposer_duty
+    urls:
+      - https://data.ethpandaops.io/xatu/mainnet/databases/default/beacon_api_eth_v1_proposer_duty/2024/10/15.parquet
+
+assertions:
+  - slot: 1234567
+    expected_proposer: 98765
+  - slot: 1234568
+    expected_block_root: "0xabcd..."

--- a/tests/data-sets/minimal.yaml
+++ b/tests/data-sets/minimal.yaml
@@ -1,0 +1,19 @@
+name: minimal
+description: "Minimal test data for basic validation"
+network: mainnet
+tables:
+  - name: canonical_beacon_block
+    urls:
+      - https://data.ethpandaops.io/xatu/mainnet/databases/default/canonical_beacon_block/2024/10/15.parquet
+    
+  - name: beacon_api_eth_v1_events_block
+    urls:
+      - https://data.ethpandaops.io/xatu/mainnet/databases/default/beacon_api_eth_v1_events_block/2024/10/15.parquet
+
+  - name: beacon_api_eth_v1_proposer_duty
+    urls:
+      - https://data.ethpandaops.io/xatu/mainnet/databases/default/beacon_api_eth_v1_proposer_duty/2024/10/15.parquet
+
+assertions:
+  - slot: 1234567
+    expected_proposer: 98765

--- a/tests/framework/assertions.go
+++ b/tests/framework/assertions.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"time"
+
+	_ "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+type TestDefinition struct {
+	Tests []Test `yaml:"tests"`
+}
+
+type Test struct {
+	Name       string      `yaml:"name"`
+	DataSet    string      `yaml:"data_set"`
+	Assertions []Assertion `yaml:"assertions"`
+}
+
+type Assertion struct {
+	Query    string                 `yaml:"query"`
+	Expected map[string]interface{} `yaml:"expected"`
+}
+
+func main() {
+	var (
+		pattern        string
+		databasePrefix string
+	)
+
+	flag.StringVar(&pattern, "pattern", "*.test.yaml", "Test file pattern")
+	flag.StringVar(&databasePrefix, "database-prefix", "", "Database prefix for isolation")
+	flag.Parse()
+
+	log := logrus.New()
+	log.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp: true,
+	})
+
+	if databasePrefix == "" {
+		log.Fatal("--database-prefix flag is required")
+	}
+
+	ctx := context.Background()
+
+	if err := runAssertions(ctx, log, pattern, databasePrefix); err != nil {
+		log.WithError(err).Fatal("Assertions failed")
+	}
+}
+
+func runAssertions(ctx context.Context, log *logrus.Logger, pattern string, databasePrefix string) error {
+	testFiles, err := filepath.Glob(filepath.Join("models", "**", pattern))
+	if err != nil {
+		return fmt.Errorf("failed to find test files: %w", err)
+	}
+
+	if len(testFiles) == 0 {
+		log.WithField("pattern", pattern).Info("No test files found")
+		return nil
+	}
+
+	dsn := fmt.Sprintf("clickhouse://localhost:9000/%smainnet?compress=true", databasePrefix)
+	db, err := sql.Open("clickhouse", dsn)
+	if err != nil {
+		return fmt.Errorf("failed to connect to ClickHouse: %w", err)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(5)
+	db.SetMaxIdleConns(2)
+	db.SetConnMaxLifetime(time.Hour)
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("failed to ping ClickHouse: %w", err)
+	}
+
+	totalPassed := 0
+	totalFailed := 0
+
+	for _, testFile := range testFiles {
+		log.WithField("file", testFile).Info("Running test file")
+
+		data, err := os.ReadFile(testFile)
+		if err != nil {
+			return fmt.Errorf("failed to read test file %s: %w", testFile, err)
+		}
+
+		var testDef TestDefinition
+		if err := yaml.Unmarshal(data, &testDef); err != nil {
+			return fmt.Errorf("failed to parse test file %s: %w", testFile, err)
+		}
+
+		for _, test := range testDef.Tests {
+			log.WithField("test", test.Name).Info("Running test")
+
+			for i, assertion := range test.Assertions {
+				if err := runAssertion(ctx, db, assertion); err != nil {
+					log.WithFields(logrus.Fields{
+						"test":      test.Name,
+						"assertion": i + 1,
+						"query":     assertion.Query,
+					}).WithError(err).Error("Assertion failed")
+					totalFailed++
+				} else {
+					log.WithFields(logrus.Fields{
+						"test":      test.Name,
+						"assertion": i + 1,
+					}).Debug("Assertion passed")
+					totalPassed++
+				}
+			}
+		}
+	}
+
+	log.WithFields(logrus.Fields{
+		"passed": totalPassed,
+		"failed": totalFailed,
+	}).Info("Test run completed")
+
+	if totalFailed > 0 {
+		return fmt.Errorf("%d assertions failed", totalFailed)
+	}
+
+	return nil
+}
+
+func runAssertion(ctx context.Context, db *sql.DB, assertion Assertion) error {
+	rows, err := db.QueryContext(ctx, assertion.Query)
+	if err != nil {
+		return fmt.Errorf("query failed: %w", err)
+	}
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("failed to get columns: %w", err)
+	}
+
+	if !rows.Next() {
+		return fmt.Errorf("no results returned")
+	}
+
+	values := make([]interface{}, len(columns))
+	valuePtrs := make([]interface{}, len(columns))
+	for i := range values {
+		valuePtrs[i] = &values[i]
+	}
+
+	if err := rows.Scan(valuePtrs...); err != nil {
+		return fmt.Errorf("failed to scan row: %w", err)
+	}
+
+	for i, col := range columns {
+		expected, ok := assertion.Expected[col]
+		if !ok {
+			continue
+		}
+
+		actual := values[i]
+
+		actualValue := normalizeValue(actual)
+		expectedValue := normalizeValue(expected)
+
+		if !reflect.DeepEqual(actualValue, expectedValue) {
+			return fmt.Errorf("column %s: expected %v (type %T), got %v (type %T)",
+				col, expectedValue, expectedValue, actualValue, actualValue)
+		}
+	}
+
+	return nil
+}
+
+func normalizeValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case []uint8:
+		return string(val)
+	case int64:
+		return val
+	case float64:
+		return val
+	case int:
+		return int64(val)
+	case float32:
+		return float64(val)
+	case uint64:
+		return int64(val)
+	case uint32:
+		return int64(val)
+	case nil:
+		return nil
+	default:
+		return v
+	}
+}

--- a/tests/framework/go.mod
+++ b/tests/framework/go.mod
@@ -1,0 +1,9 @@
+module github.com/ethpandaops/xatu-cbt/tests/framework
+
+go 1.23
+
+require (
+	github.com/ClickHouse/clickhouse-go/v2 v2.40.1
+	github.com/sirupsen/logrus v1.9.3
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/tests/framework/loader.go
+++ b/tests/framework/loader.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	_ "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+type DataSet struct {
+	Name        string      `yaml:"name"`
+	Description string      `yaml:"description"`
+	Network     string      `yaml:"network"`
+	Tables      []Table     `yaml:"tables"`
+	Assertions  []Assertion `yaml:"assertions"`
+}
+
+type Table struct {
+	Name string   `yaml:"name"`
+	URLs []string `yaml:"urls"`
+}
+
+type Assertion struct {
+	Slot             int    `yaml:"slot"`
+	ExpectedProposer int    `yaml:"expected_proposer"`
+	ExpectedRoot     string `yaml:"expected_block_root"`
+}
+
+func main() {
+	var (
+		dataSetPath    string
+		databasePrefix string
+	)
+
+	flag.StringVar(&dataSetPath, "data-set", "", "Path to data set YAML file")
+	flag.StringVar(&databasePrefix, "database-prefix", "", "Database prefix for isolation")
+	flag.Parse()
+
+	log := logrus.New()
+	log.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp: true,
+	})
+
+	if dataSetPath == "" {
+		log.Fatal("--data-set flag is required")
+	}
+
+	if databasePrefix == "" {
+		log.Fatal("--database-prefix flag is required")
+	}
+
+	ctx := context.Background()
+
+	if err := loadDataSet(ctx, log, dataSetPath, databasePrefix); err != nil {
+		log.WithError(err).Fatal("Failed to load data set")
+	}
+}
+
+func loadDataSet(ctx context.Context, log *logrus.Logger, dataSetPath string, databasePrefix string) error {
+	data, err := os.ReadFile(dataSetPath)
+	if err != nil {
+		return fmt.Errorf("failed to read data set file: %w", err)
+	}
+
+	var dataSet DataSet
+	if err := yaml.Unmarshal(data, &dataSet); err != nil {
+		return fmt.Errorf("failed to parse data set YAML: %w", err)
+	}
+
+	log.WithField("dataset", dataSet.Name).Info("Loading data set")
+
+	dsn := fmt.Sprintf("clickhouse://localhost:9000/%smainnet?compress=true", databasePrefix)
+	db, err := sql.Open("clickhouse", dsn)
+	if err != nil {
+		return fmt.Errorf("failed to connect to ClickHouse: %w", err)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(time.Hour)
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("failed to ping ClickHouse: %w", err)
+	}
+
+	for _, table := range dataSet.Tables {
+		for _, url := range table.URLs {
+			log.WithFields(logrus.Fields{
+				"table": table.Name,
+				"url":   url,
+			}).Info("Loading parquet file")
+
+			// Tables already exist from xatu migrations
+			// Just insert into the existing table structure
+			tableName := fmt.Sprintf("%s%s.%s", databasePrefix, dataSet.Network, table.Name)
+
+			query := fmt.Sprintf(`
+				INSERT INTO %s
+				SELECT * FROM url('%s', 'Parquet')
+			`, tableName, url)
+
+			if _, err := db.ExecContext(ctx, query); err != nil {
+				return fmt.Errorf("failed to load data from %s into %s: %w", url, tableName, err)
+			}
+
+			var count int
+			countQuery := fmt.Sprintf("SELECT count(*) FROM %s", tableName)
+			if err := db.QueryRowContext(ctx, countQuery).Scan(&count); err != nil {
+				return fmt.Errorf("failed to count rows in %s: %w", tableName, err)
+			}
+
+			log.WithFields(logrus.Fields{
+				"table": tableName,
+				"rows":  count,
+			}).Info("Data loaded successfully")
+		}
+	}
+
+	log.Info("Data set loading completed")
+	return nil
+}

--- a/tests/framework/runner.go
+++ b/tests/framework/runner.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	_ "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	var (
+		pattern        string
+		timeout        int
+		databasePrefix string
+	)
+
+	flag.StringVar(&pattern, "pattern", "*.test.yaml", "Test file pattern")
+	flag.IntVar(&timeout, "timeout", 300, "Timeout in seconds")
+	flag.StringVar(&databasePrefix, "database-prefix", "", "Database prefix for isolation")
+	flag.Parse()
+
+	log := logrus.New()
+	log.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp: true,
+	})
+
+	if databasePrefix == "" {
+		log.Fatal("--database-prefix flag is required")
+	}
+
+	ctx := context.Background()
+
+	if err := runTests(ctx, log, pattern, databasePrefix, timeout); err != nil {
+		log.WithError(err).Fatal("Failed to run tests")
+	}
+}
+
+func runTests(ctx context.Context, log *logrus.Logger, pattern string, databasePrefix string, timeout int) error {
+	testFiles, err := filepath.Glob(filepath.Join("models", "**", pattern))
+	if err != nil {
+		return fmt.Errorf("failed to find test files: %w", err)
+	}
+
+	if len(testFiles) == 0 {
+		log.WithField("pattern", pattern).Warn("No test files found")
+		return nil
+	}
+
+	log.WithField("files", len(testFiles)).Info("Found test files")
+
+	dsn := fmt.Sprintf("clickhouse://localhost:9000/%sadmin?compress=true", databasePrefix)
+	db, err := sql.Open("clickhouse", dsn)
+	if err != nil {
+		return fmt.Errorf("failed to connect to ClickHouse: %w", err)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(5)
+	db.SetMaxIdleConns(2)
+	db.SetConnMaxLifetime(time.Hour)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("failed to ping ClickHouse: %w", err)
+	}
+
+	startTime := time.Now()
+	pollInterval := 5 * time.Second
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for transformations to complete")
+		case <-time.After(pollInterval):
+			completed, err := checkTransformationStatus(ctx, db, databasePrefix)
+			if err != nil {
+				log.WithError(err).Warn("Failed to check transformation status")
+				continue
+			}
+
+			if completed {
+				log.WithField("duration", time.Since(startTime)).Info("All transformations completed")
+				return nil
+			}
+
+			log.WithField("elapsed", time.Since(startTime)).Info("Waiting for transformations to complete")
+		}
+	}
+}
+
+func checkTransformationStatus(ctx context.Context, db *sql.DB, databasePrefix string) (bool, error) {
+	// Check if any transformations have been processed
+	query := fmt.Sprintf(`
+		SELECT 
+			database,
+			table,
+			COUNT(*) as processed_intervals
+		FROM %sadmin.cbt
+		GROUP BY database, table
+	`, databasePrefix)
+
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		// Table might not exist yet
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check transformation status: %w", err)
+	}
+	defer rows.Close()
+
+	modelCount := 0
+	for rows.Next() {
+		var database, table string
+		var processedIntervals int
+		if err := rows.Scan(&database, &table, &processedIntervals); err != nil {
+			return false, fmt.Errorf("failed to scan transformation status: %w", err)
+		}
+		modelCount++
+	}
+
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("rows iteration error: %w", err)
+	}
+
+	// Consider transformations complete if we have processed at least one model
+	return modelCount > 0, nil
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -e
+
+# Configuration
+TEST_PATTERN="${1:-*.test.yaml}"
+DATA_SET="${2:-minimal}"
+VERBOSE="${3:-false}"
+
+# Generate unique test ID for database isolation
+TEST_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)
+export CBT_DATABASE_PREFIX="test_${TEST_ID}_"
+
+echo "🧪 xatu-cbt Test Runner"
+echo "━━━━━━━━━━━━━━━━━━━━━"
+echo "📝 Test ID: $TEST_ID"
+echo "🗄️  Database prefix: $CBT_DATABASE_PREFIX"
+
+# Cleanup function
+cleanup() {
+  echo "🧹 Cleaning up test databases..."
+  clickhouse-client -q "DROP DATABASE IF EXISTS ${CBT_DATABASE_PREFIX}mainnet"
+  clickhouse-client -q "DROP DATABASE IF EXISTS ${CBT_DATABASE_PREFIX}admin"
+}
+trap cleanup EXIT
+
+# 1. Bootstrap ClickHouse
+echo "📦 Starting ClickHouse..."
+(cd vendor/xatu && docker compose --profile clickhouse up -d)
+
+# 2. Wait for ClickHouse health
+echo "⏳ Waiting for ClickHouse..."
+until curl -s "http://localhost:8123/ping" > /dev/null 2>&1; do
+  sleep 2
+done
+
+# 3. Create isolated databases
+echo "🏗️  Creating test databases..."
+clickhouse-client -q "CREATE DATABASE IF NOT EXISTS ${CBT_DATABASE_PREFIX}mainnet"
+clickhouse-client -q "CREATE DATABASE IF NOT EXISTS ${CBT_DATABASE_PREFIX}admin"
+
+# 3a. Run xatu migrations to create base tables in isolated databases
+echo "🔧 Running xatu migrations..."
+docker run --rm \
+  --network xatu_xatu-net \
+  -v $(pwd)/vendor/xatu/deploy/migrations/clickhouse:/migrations \
+  migrate/migrate \
+  -path=/migrations \
+  -database "clickhouse://xatu-clickhouse-01:9000?database=${CBT_DATABASE_PREFIX}mainnet&x-migrations-table=schema_migrations_xatu" \
+  up
+
+# 4. Load test data into isolated database
+echo "📥 Loading data set: $DATA_SET"
+go run tests/framework/loader.go \
+  --data-set "tests/data-sets/$DATA_SET.yaml" \
+  --database-prefix "$CBT_DATABASE_PREFIX"
+
+# 5. Run CBT migrations with isolation
+echo "🔄 Running migrations..."
+docker compose -f docker-compose.test.yml run --rm \
+  -e CBT_DATABASE_PREFIX="$CBT_DATABASE_PREFIX" \
+  cbt-migrator
+
+# 6. Start CBT engine with isolation
+echo "🚀 Starting CBT engine..."
+docker compose -f docker-compose.test.yml run -d \
+  -e CBT_DATABASE_PREFIX="$CBT_DATABASE_PREFIX" \
+  --name "cbt-engine-$TEST_ID" \
+  cbt-engine
+
+# 7. Wait for transformations
+echo "⏳ Processing transformations..."
+go run tests/framework/runner.go \
+  --pattern "$TEST_PATTERN" \
+  --timeout 300 \
+  --database-prefix "$CBT_DATABASE_PREFIX"
+
+# 8. Run assertions
+echo "✅ Running assertions..."
+go run tests/framework/assertions.go \
+  --pattern "$TEST_PATTERN" \
+  --database-prefix "$CBT_DATABASE_PREFIX"
+
+echo "━━━━━━━━━━━━━━━━━━━━━"
+echo "✨ All tests passed!"


### PR DESCRIPTION
## Summary
- Implements a minimal testing framework for validating SQL transformations
- Loads parquet files from data.ethpandaops.io and asserts exact query results
- Related to https://github.com/ethpandaops/cbt/pull/14

## Test plan
- [ ] Run `./tests/run-tests.sh` to execute minimal test suite
- [ ] Verify database isolation works with multiple concurrent test runs
- [ ] Confirm cleanup removes all test databases after completion

🤖 Generated with [Claude Code](https://claude.ai/code)