### PR TITLE
refactor: unify interval and schedule configuration for SQL transformations

### DIFF
--- a/models/transformations/mainnet/intermediate/address/account_first_access.sql
+++ b/models/transformations/mainnet/intermediate/address/account_first_access.sql
@@ -1,12 +1,11 @@
 ---
 database: mainnet
 table: int_address__account_first_access
-forwardfill:
-  interval: 10
-  schedule: "@every 5m"
-backfill:
-  interval: 10000
-  schedule: "@every 1m"
+interval:
+  max: 10000
+schedules:
+  forwardfill: "@every 1m"
+  backfill: "@every 1m"
 tags:
   - mainnet
   - address

--- a/models/transformations/mainnet/intermediate/address/account_last_access.sql
+++ b/models/transformations/mainnet/intermediate/address/account_last_access.sql
@@ -1,12 +1,11 @@
 ---
 database: mainnet
 table: int_address__account_last_access
-forwardfill:
-  interval: 10
-  schedule: "@every 5m"
-backfill:
-  interval: 10000
-  schedule: "@every 1m"
+interval:
+  max: 10000
+schedules:
+  forwardfill: "@every 1m"
+  backfill: "@every 1m"
 tags:
   - mainnet
   - address

--- a/models/transformations/mainnet/intermediate/address/storage_slot_first_access.sql
+++ b/models/transformations/mainnet/intermediate/address/storage_slot_first_access.sql
@@ -1,12 +1,11 @@
 ---
 database: mainnet
 table: int_address__storage_slot_first_access
-forwardfill:
-  interval: 1000
-  schedule: "@every 10s"
-backfill:
-  interval: 1000
-  schedule: "@every 10s"
+interval:
+  max: 1000
+schedules:
+  forwardfill: "@every 1m"
+  backfill: "@every 1m"
 tags:
   - mainnet
   - address

--- a/models/transformations/mainnet/intermediate/address/storage_slot_last_access.sql
+++ b/models/transformations/mainnet/intermediate/address/storage_slot_last_access.sql
@@ -1,12 +1,11 @@
 ---
 database: mainnet
 table: int_address__storage_slot_last_access
-forwardfill:
-  interval: 1000
-  schedule: "@every 10s"
-backfill:
-  interval: 1000
-  schedule: "@every 10s"
+interval:
+  max: 1000
+schedules:
+  forwardfill: "@every 1m"
+  backfill: "@every 1m"
 tags:
   - mainnet
   - address

--- a/models/transformations/mainnet/intermediate/slot/block_proposer_canonical.sql
+++ b/models/transformations/mainnet/intermediate/slot/block_proposer_canonical.sql
@@ -1,12 +1,11 @@
 ---
 database: mainnet
 table: int_slot__block_proposer_canonical
-forwardfill:
-  interval: 72
-  schedule: "@every 30s"
-backfill:
-  interval: 5000
-  schedule: "@every 1m"
+interval:
+  max: 5000
+schedules:
+  forwardfill: "@every 1m"
+  backfill: "@every 1m"
 tags:
   - mainnet
   - slot

--- a/models/transformations/mainnet/intermediate/slot/block_proposer_head.sql
+++ b/models/transformations/mainnet/intermediate/slot/block_proposer_head.sql
@@ -1,12 +1,11 @@
 ---
 database: mainnet
 table: int_slot__block_proposer_head
-forwardfill:
-  interval: 12
-  schedule: "@every 5s"
-backfill:
-  interval: 5000
-  schedule: "@every 1m"
+interval:
+  max: 5000
+schedules:
+  forwardfill: "@every 5s"
+  backfill: "@every 1m"
 tags:
   - mainnet
   - slot


### PR DESCRIPTION
- Replace separate forwardfill/backfill configs with unified interval.max
- Consolidate schedules into single section with forwardfill/backfill timings
- Standardize most schedules to @every 1m for consistency