### PR TITLE
ci: add debug-ci workflow and helper scripts for troubleshooting migrations

### DIFF
--- a/debug_ci.yaml
+++ b/debug_ci.yaml
@@ -1,0 +1,72 @@
+name: debug-ci
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'debug_ci.yaml'
+
+jobs:
+  debug-environment:
+    name: Debug CI Environment
+    runs-on:
+      - self-hosted-ghr
+      - size-s-x64
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Check Docker version
+        run: |
+          echo "=== Docker Version ==="
+          docker version
+          echo ""
+          echo "=== Docker Compose Version ==="
+          docker compose version
+      
+      - name: Check Xatu ref
+        run: |
+          echo "=== Checking Xatu Repository ==="
+          git ls-remote https://github.com/ethpandaops/xatu.git HEAD
+          echo ""
+          echo "Input ref: ${{ github.event.inputs.xatu_ref || 'master' }}"
+      
+      - name: Clone and check Xatu migrations
+        run: |
+          git clone https://github.com/ethpandaops/xatu.git xatu-temp
+          cd xatu-temp
+          git checkout ${{ github.event.inputs.xatu_ref || 'master' }}
+          echo "=== Current Xatu commit ==="
+          git log -1 --oneline
+          echo ""
+          echo "=== Checking for beacon_api_eth_v1_events_block in migrations ==="
+          grep -r "beacon_api_eth_v1_events_block" deploy/migrations/ || echo "Not found in migrations"
+          echo ""
+          echo "=== List all migration files ==="
+          find deploy/migrations -name "*.sql" | sort
+          cd ..
+          rm -rf xatu-temp
+      
+      - name: Setup and run minimal test
+        run: |
+          cp example.env .env
+          make build
+          
+          # Clone Xatu
+          git clone https://github.com/ethpandaops/xatu.git xatu
+          cd xatu && git checkout ${{ github.event.inputs.xatu_ref || 'master' }} && cd ..
+          
+          # Start only ClickHouse
+          cd xatu
+          docker compose --profile clickhouse up -d
+          cd ..
+          
+          # Wait for migrations
+          echo "Waiting for migrations..."
+          timeout 600 bash -c 'while docker ps | grep -q xatu-clickhouse-migrator; do sleep 5; done'
+          
+          # Check what tables exist
+          echo "=== Tables in default database ==="
+          docker exec xatu-clickhouse-01 clickhouse-client -q "SELECT name FROM system.tables WHERE database = 'default' AND name LIKE '%beacon_api%' ORDER BY name"
+          
+          # Check migration logs
+          echo "=== Last 20 lines of migration logs ==="
+          docker logs xatu-clickhouse-migrator 2>&1 | tail -20

--- a/debug_tables.sh
+++ b/debug_tables.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "=== Checking ClickHouse Tables After Migration ==="
+echo ""
+
+echo "1. All databases:"
+docker exec xatu-clickhouse-01 clickhouse-client -q "SHOW DATABASES"
+echo ""
+
+echo "2. Tables in 'default' database:"
+docker exec xatu-clickhouse-01 clickhouse-client -q "SHOW TABLES FROM default" | head -20
+echo ""
+
+echo "3. Tables matching 'beacon_api_eth_v1_events%':"
+docker exec xatu-clickhouse-01 clickhouse-client -q "SELECT database, name FROM system.tables WHERE name LIKE '%beacon_api_eth_v1_events%' ORDER BY database, name"
+echo ""
+
+echo "4. Specific check for beacon_api_eth_v1_events_block:"
+docker exec xatu-clickhouse-01 clickhouse-client -q "SELECT database, name, engine FROM system.tables WHERE name = 'beacon_api_eth_v1_events_block'"
+echo ""
+
+echo "5. Migration logs (last 50 lines):"
+docker logs xatu-clickhouse-migrator 2>&1 | tail -50


### PR DESCRIPTION
Add debug_ci.yaml workflow that runs on PR changes to debug the CI environment, including Docker versions, Xatu repository state, and migration outcomes. Introduce debug_tables.sh script for quick table inspection and enhance data_loader.go with checkTableExists to provide better error reporting when expected tables are missing.