### PR TITLE
refactor: update table names to follow naming conventions

### DIFF
--- a/migrations/003_execution_accounts.down.sql
+++ b/migrations/003_execution_accounts.down.sql
@@ -1,8 +1,8 @@
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address__account_last_access ON CLUSTER '{cluster}';
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address__account_last_access_local ON CLUSTER '{cluster}';
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address__account_first_access ON CLUSTER '{cluster}';
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address__account_first_access_local ON CLUSTER '{cluster}';
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address__storage_slot_last_access ON CLUSTER '{cluster}';
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address__storage_slot_last_access_local ON CLUSTER '{cluster}';
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address__storage_slot_first_access ON CLUSTER '{cluster}';
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address__storage_slot_first_access_local ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address__last_access ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address__last_access_local ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address__first_access ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address__first_access_local ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address_storage__last_access ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address_storage__last_access_local ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address_storage__first_access ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_address_storage__first_access_local ON CLUSTER '{cluster}';

--- a/migrations/003_execution_accounts.up.sql
+++ b/migrations/003_execution_accounts.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `${NETWORK_NAME}`.int_address__account_last_access_local on cluster '{cluster}' (
+CREATE TABLE `${NETWORK_NAME}`.int_address__last_access_local on cluster '{cluster}' (
     `address` String COMMENT 'The address of the account' CODEC(ZSTD(1)),
     `block_number` UInt32 COMMENT 'The block number of the last access' CODEC(ZSTD(1)),
 ) ENGINE = ReplicatedReplacingMergeTree(
@@ -9,14 +9,14 @@ CREATE TABLE `${NETWORK_NAME}`.int_address__account_last_access_local on cluster
 ORDER BY
     (address) COMMENT 'Table for accounts last access data';
 
-CREATE TABLE `${NETWORK_NAME}`.int_address__account_last_access ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_address__account_last_access_local ENGINE = Distributed(
+CREATE TABLE `${NETWORK_NAME}`.int_address__last_access ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_address__last_access_local ENGINE = Distributed(
     '{cluster}',
     '${NETWORK_NAME}',
-    int_address__account_last_access_local,
+    int_address__last_access_local,
     cityHash64(`address`)
 );
 
-CREATE TABLE `${NETWORK_NAME}`.int_address__account_first_access_local on cluster '{cluster}' (
+CREATE TABLE `${NETWORK_NAME}`.int_address__first_access_local on cluster '{cluster}' (
     `address` String COMMENT 'The address of the account' CODEC(ZSTD(1)),
     `block_number` UInt32 COMMENT 'The block number of the first access' CODEC(ZSTD(1)),
     `version` UInt32 DEFAULT 4294967295 - block_number COMMENT 'Version for this address, for internal use in clickhouse to keep first access' CODEC(DoubleDelta, ZSTD(1))
@@ -28,14 +28,14 @@ CREATE TABLE `${NETWORK_NAME}`.int_address__account_first_access_local on cluste
 ORDER BY
     (address) COMMENT 'Table for accounts first access data';
 
-CREATE TABLE `${NETWORK_NAME}`.int_address__account_first_access ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_address__account_first_access_local ENGINE = Distributed(
+CREATE TABLE `${NETWORK_NAME}`.int_address__first_access ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_address__first_access_local ENGINE = Distributed(
     '{cluster}',
     '${NETWORK_NAME}',
-    int_address__account_first_access_local,
+    int_address__first_access_local,
     cityHash64(`address`)
 );
 
-CREATE TABLE `${NETWORK_NAME}`.int_address__storage_slot_last_access_local on cluster '{cluster}' (
+CREATE TABLE `${NETWORK_NAME}`.int_address_storage__last_access_local on cluster '{cluster}' (
     `address` String COMMENT 'The address of the account' CODEC(ZSTD(1)),
     `slot_key` String COMMENT 'The slot key of the storage' CODEC(ZSTD(1)),
     `block_number` UInt32 COMMENT 'The block number of the last access' CODEC(ZSTD(1)),
@@ -47,14 +47,14 @@ CREATE TABLE `${NETWORK_NAME}`.int_address__storage_slot_last_access_local on cl
 ) PARTITION BY cityHash64(`address`) % 16
 ORDER BY (address, slot_key) COMMENT 'Table for storage last access data';
 
-CREATE TABLE `${NETWORK_NAME}`.int_address__storage_slot_last_access ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_address__storage_slot_last_access_local ENGINE = Distributed(
+CREATE TABLE `${NETWORK_NAME}`.int_address_storage__last_access ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_address_storage__last_access_local ENGINE = Distributed(
     '{cluster}',
     '${NETWORK_NAME}',
-    int_address__storage_slot_last_access_local,
+    int_address_storage__last_access_local,
     cityHash64(`address`, `slot_key`)
 );
 
-CREATE TABLE `${NETWORK_NAME}`.int_address__storage_slot_first_access_local on cluster '{cluster}' (
+CREATE TABLE `${NETWORK_NAME}`.int_address_storage__first_access_local on cluster '{cluster}' (
     `address` String COMMENT 'The address of the account' CODEC(ZSTD(1)),
     `slot_key` String COMMENT 'The slot key of the storage' CODEC(ZSTD(1)),
     `block_number` UInt32 COMMENT 'The block number of the first access' CODEC(ZSTD(1)),
@@ -67,9 +67,9 @@ CREATE TABLE `${NETWORK_NAME}`.int_address__storage_slot_first_access_local on c
 ) PARTITION BY cityHash64(`address`) % 16
 ORDER BY (address, slot_key) COMMENT 'Table for storage first access data';
 
-CREATE TABLE `${NETWORK_NAME}`.int_address__storage_slot_first_access ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_address__storage_slot_first_access_local ENGINE = Distributed(
+CREATE TABLE `${NETWORK_NAME}`.int_address_storage__first_access ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_address_storage__first_access_local ENGINE = Distributed(
     '{cluster}',
     '${NETWORK_NAME}',
-    int_address__storage_slot_first_access_local,
+    int_address_storage__first_access_local,
     cityHash64(`address`, `slot_key`)
 );

--- a/migrations/004_block_proposal.down.sql
+++ b/migrations/004_block_proposal.down.sql
@@ -1,4 +1,4 @@
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_slot__block_proposer_head ON CLUSTER '{cluster}';
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_slot__block_proposer_head_local ON CLUSTER '{cluster}';
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_slot__block_proposer_canonical ON CLUSTER '{cluster}';
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_slot__block_proposer_canonical_local ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_block_proposer__head ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_block_proposer__head_local ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_block_proposer__canonical ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_block_proposer__canonical_local ON CLUSTER '{cluster}';

--- a/migrations/004_block_proposal.up.sql
+++ b/migrations/004_block_proposal.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `${NETWORK_NAME}`.int_slot__block_proposer_head_local on cluster '{cluster}' (
+CREATE TABLE `${NETWORK_NAME}`.int_block_proposer__head_local on cluster '{cluster}' (
     `updated_date_time` DateTime COMMENT 'Timestamp when the record was last updated' CODEC(DoubleDelta, ZSTD(1)),
     `slot` UInt32 COMMENT 'The slot number for which the proposer duty is assigned' CODEC(DoubleDelta, ZSTD(1)),
     `slot_start_date_time` DateTime COMMENT 'The wall clock time when the slot started' CODEC(DoubleDelta, ZSTD(1)),
@@ -15,14 +15,14 @@ CREATE TABLE `${NETWORK_NAME}`.int_slot__block_proposer_head_local on cluster '{
 ORDER BY
     (`slot_start_date_time`, `proposer_validator_index`) COMMENT 'Block proposers for the unfinalized chain. Forks in the chain may cause mulitple proposers for the same slot to be present';
 
-CREATE TABLE `${NETWORK_NAME}`.int_slot__block_proposer_head ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_slot__block_proposer_head_local ENGINE = Distributed(
+CREATE TABLE `${NETWORK_NAME}`.int_block_proposer__head ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_block_proposer__head_local ENGINE = Distributed(
     '{cluster}',
     '${NETWORK_NAME}',
-    int_slot__block_proposer_head_local,
+    int_block_proposer__head_local,
     cityHash64(`slot_start_date_time`, `proposer_validator_index`)
 );
 
-CREATE TABLE `${NETWORK_NAME}`.int_slot__block_proposer_canonical_local on cluster '{cluster}' (
+CREATE TABLE `${NETWORK_NAME}`.int_block_proposer__canonical_local on cluster '{cluster}' (
     `updated_date_time` DateTime COMMENT 'Timestamp when the record was last updated' CODEC(DoubleDelta, ZSTD(1)),
     `slot` UInt32 COMMENT 'The slot number for which the proposer duty is assigned' CODEC(DoubleDelta, ZSTD(1)),
     `slot_start_date_time` DateTime COMMENT 'The wall clock time when the slot started' CODEC(DoubleDelta, ZSTD(1)),
@@ -39,9 +39,9 @@ CREATE TABLE `${NETWORK_NAME}`.int_slot__block_proposer_canonical_local on clust
 ORDER BY
     (`slot_start_date_time`) COMMENT 'Block proposers for the finalized chain';
 
-CREATE TABLE `${NETWORK_NAME}`.int_slot__block_proposer_canonical ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_slot__block_proposer_canonical_local ENGINE = Distributed(
+CREATE TABLE `${NETWORK_NAME}`.int_block_proposer__canonical ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_block_proposer__canonical_local ENGINE = Distributed(
     '{cluster}',
     '${NETWORK_NAME}',
-    int_slot__block_proposer_canonical_local,
+    int_block_proposer__canonical_local,
     cityHash64(`slot_start_date_time`)
 );

--- a/models/transformations/int_address__first_access.sql
+++ b/models/transformations/int_address__first_access.sql
@@ -1,5 +1,5 @@
 ---
-table: int_address__account_last_access
+table: int_address__first_access
 interval:
   max: 10000
 schedules:
@@ -21,7 +21,8 @@ INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`
 SELECT 
     address,
-    max(block_number) AS block_number
+    min(block_number) AS block_number,
+    null AS `version`
 FROM (
     SELECT lower(address) as address, block_number FROM `{{ index .dep "{{external}}" "canonical_execution_nonce_reads" "database" }}`.`canonical_execution_nonce_reads` FINAL
     WHERE block_number BETWEEN {{ .bounds.start }} AND {{ .bounds.end }}

--- a/models/transformations/int_address__last_access.sql
+++ b/models/transformations/int_address__last_access.sql
@@ -1,5 +1,5 @@
 ---
-table: int_address__account_first_access
+table: int_address__last_access
 interval:
   max: 10000
 schedules:
@@ -21,8 +21,7 @@ INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`
 SELECT 
     address,
-    min(block_number) AS block_number,
-    null AS `version`
+    max(block_number) AS block_number
 FROM (
     SELECT lower(address) as address, block_number FROM `{{ index .dep "{{external}}" "canonical_execution_nonce_reads" "database" }}`.`canonical_execution_nonce_reads` FINAL
     WHERE block_number BETWEEN {{ .bounds.start }} AND {{ .bounds.end }}

--- a/models/transformations/int_address_storage__first_access.sql
+++ b/models/transformations/int_address_storage__first_access.sql
@@ -1,5 +1,5 @@
 ---
-table: int_address__storage_slot_first_access
+table: int_address_storage__first_access
 interval:
   max: 1000
 schedules:

--- a/models/transformations/int_address_storage__last_access.sql
+++ b/models/transformations/int_address_storage__last_access.sql
@@ -1,5 +1,5 @@
 ---
-table: int_address__storage_slot_last_access
+table: int_address_storage__last_access
 interval:
   max: 1000
 schedules:

--- a/models/transformations/int_block_proposer__canonical.sql
+++ b/models/transformations/int_block_proposer__canonical.sql
@@ -1,5 +1,5 @@
 ---
-table: int_slot__block_proposer_canonical
+table: int_block_proposer__canonical
 interval:
   max: 500000
 schedules:

--- a/models/transformations/int_block_proposer__head.sql
+++ b/models/transformations/int_block_proposer__head.sql
@@ -1,5 +1,5 @@
 ---
-table: int_slot__block_proposer_head
+table: int_block_proposer__head
 interval:
   max: 500000
 schedules:

--- a/tests/pectra/assertions/int_address__first_access.yaml
+++ b/tests/pectra/assertions/int_address__first_access.yaml
@@ -5,7 +5,7 @@
       MIN(block_number) AS min,
       MAX(block_number) AS max
     FROM
-      int_address__account_first_access FINAL
+      int_address__first_access FINAL
   expected:
     count: 94577
     min: "20000000"
@@ -18,7 +18,7 @@
     FROM
       admin_cbt FINAL
     WHERE
-      table = 'int_address__account_first_access'
+      table = 'int_address__first_access'
   expected:
     min: "20000000"
     max: "20000994"

--- a/tests/pectra/assertions/int_address__last_access.yaml
+++ b/tests/pectra/assertions/int_address__last_access.yaml
@@ -5,11 +5,11 @@
       MIN(block_number) AS min,
       MAX(block_number) AS max
     FROM
-      int_address__storage_slot_last_access FINAL
+      int_address__last_access FINAL
   expected:
-    count: 353565
+    count: 94577
     min: "20000000"
-    max: "20000999"
+    max: "20000994"
 - name: "Expected admin bounds"
   sql: |
     SELECT
@@ -18,7 +18,7 @@
     FROM
       admin_cbt FINAL
     WHERE
-      table = 'int_address__storage_slot_last_access'
+      table = 'int_address__last_access'
   expected:
     min: "20000000"
-    max: "20000999"
+    max: "20000994"

--- a/tests/pectra/assertions/int_address_storage__first_access.yaml
+++ b/tests/pectra/assertions/int_address_storage__first_access.yaml
@@ -5,7 +5,7 @@
       MIN(block_number) AS min,
       MAX(block_number) AS max
     FROM
-      int_address__storage_slot_first_access FINAL
+      int_address_storage__first_access FINAL
   expected:
     count: 353565
     min: "20000000"
@@ -18,7 +18,7 @@
     FROM
       admin_cbt FINAL
     WHERE
-      table = 'int_address__storage_slot_first_access'
+      table = 'int_address_storage__first_access'
   expected:
     min: "20000000"
     max: "20000999"

--- a/tests/pectra/assertions/int_address_storage__last_access.yaml
+++ b/tests/pectra/assertions/int_address_storage__last_access.yaml
@@ -5,11 +5,11 @@
       MIN(block_number) AS min,
       MAX(block_number) AS max
     FROM
-      int_address__account_last_access FINAL
+      int_address_storage__last_access FINAL
   expected:
-    count: 94577
+    count: 353565
     min: "20000000"
-    max: "20000994"
+    max: "20000999"
 - name: "Expected admin bounds"
   sql: |
     SELECT
@@ -18,7 +18,7 @@
     FROM
       admin_cbt FINAL
     WHERE
-      table = 'int_address__account_last_access'
+      table = 'int_address_storage__last_access'
   expected:
     min: "20000000"
-    max: "20000994"
+    max: "20000999"

--- a/tests/pectra/assertions/int_block_proposer__canonical.yaml
+++ b/tests/pectra/assertions/int_block_proposer__canonical.yaml
@@ -5,9 +5,9 @@
       MIN(slot_start_date_time) AS min,
       MAX(slot_start_date_time) AS max
     FROM
-      int_slot__block_proposer_head FINAL
+      int_block_proposer__canonical FINAL
   expected:
-    count: 7173
+    count: 7200
     min: "2025-07-15T00:00:11Z"
     max: "2025-07-15T23:59:59Z"
 - name: "Expected admin bounds"
@@ -18,7 +18,7 @@
     FROM
       admin_cbt FINAL
     WHERE
-      table = 'int_slot__block_proposer_head'
+      table = 'int_block_proposer__canonical'
   expected:
     max: "2025-07-15T23:59:59Z"
     min: "2025-07-15T00:00:11Z"

--- a/tests/pectra/assertions/int_block_proposer__head.yaml
+++ b/tests/pectra/assertions/int_block_proposer__head.yaml
@@ -5,9 +5,9 @@
       MIN(slot_start_date_time) AS min,
       MAX(slot_start_date_time) AS max
     FROM
-      int_slot__block_proposer_canonical FINAL
+      int_block_proposer__head FINAL
   expected:
-    count: 7200
+    count: 7173
     min: "2025-07-15T00:00:11Z"
     max: "2025-07-15T23:59:59Z"
 - name: "Expected admin bounds"
@@ -18,7 +18,7 @@
     FROM
       admin_cbt FINAL
     WHERE
-      table = 'int_slot__block_proposer_canonical'
+      table = 'int_block_proposer__head'
   expected:
     max: "2025-07-15T23:59:59Z"
     min: "2025-07-15T00:00:11Z"


### PR DESCRIPTION
- Rename address tables to remove redundant entity names:
  - int_address__account_first_access → int_address__first_access
  - int_address__account_last_access → int_address__last_access
  - int_address__storage_slot_first_access → int_address_storage__first_access
  - int_address__storage_slot_last_access → int_address_storage__last_access

- Rename block proposer tables to use compound source format:
  - int_slot__block_proposer_canonical → int_block_proposer__canonical
  - int_slot__block_proposer_head → int_block_proposer__head

Updates applied to models, tests, and migrations to ensure consistency across the codebase following the established naming pattern where additional context describes "how" or "when" rather than entity information.