### PR TITLE
feat: implement parallel download for test data ingestion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
+	golang.org/x/sync v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
+golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/test/data_loader.go
+++ b/pkg/test/data_loader.go
@@ -10,6 +10,7 @@ import (
 	"github.com/savid/xatu-cbt/pkg/clickhouse"
 	"github.com/savid/xatu-cbt/pkg/config"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 )
 
@@ -26,6 +27,14 @@ type dataLoader struct {
 type DataConfig struct {
 	NetworkColumn string   `yaml:"network_column"`
 	URLs          []string `yaml:"urls"`
+}
+
+// WorkItem represents a single URL to be ingested
+type WorkItem struct {
+	URL           string
+	TableName     string
+	NetworkColumn string
+	Network       string
 }
 
 // NewDataLoader creates a new data loader instance
@@ -54,6 +63,17 @@ func (d *dataLoader) LoadTestData(ctx context.Context, dataDir string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
+	// Phase 1: Collect all work items (URLs) from all files
+	workItems, err := d.collectWorkItems(files, cfg.Network)
+	if err != nil {
+		return fmt.Errorf("failed to collect work items: %w", err)
+	}
+
+	if len(workItems) == 0 {
+		d.log.Debug("No URLs found in data files, skipping data ingestion")
+		return nil
+	}
+
 	// Create ClickHouse connection
 	conn, err := clickhouse.Connect(cfg)
 	if err != nil {
@@ -65,44 +85,104 @@ func (d *dataLoader) LoadTestData(ctx context.Context, dataDir string) error {
 		}
 	}()
 
-	for _, file := range files {
-		if err := d.loadDataFile(ctx, conn, file, cfg.Network); err != nil {
-			return fmt.Errorf("failed to load data file %s: %w", file, err)
-		}
+	// Phase 2: Process work items using worker pool
+	const numWorkers = 10
+	d.log.WithFields(logrus.Fields{
+		"urls":    len(workItems),
+		"workers": numWorkers,
+	}).Info("Starting worker pool for parallel data ingestion")
+
+	// Create work channel
+	workChan := make(chan WorkItem, len(workItems))
+
+	// Feed all work items into the channel
+	for _, item := range workItems {
+		workChan <- item
+	}
+	close(workChan)
+
+	// Use errgroup for worker management
+	g, ctx := errgroup.WithContext(ctx)
+
+	// Start workers
+	for i := 0; i < numWorkers; i++ {
+		workerID := i + 1
+		g.Go(func() error {
+			return d.worker(ctx, workerID, conn, workChan)
+		})
 	}
 
+	// Wait for all workers to complete
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	d.log.Info("Completed parallel data ingestion")
 	return nil
 }
 
-func (d *dataLoader) loadDataFile(ctx context.Context, conn driver.Conn, file, network string) error {
-	d.log.WithField("file", file).Debug("Processing data file")
+// collectWorkItems reads all data files and collects URLs to be processed
+func (d *dataLoader) collectWorkItems(files []string, network string) ([]WorkItem, error) {
+	var workItems []WorkItem
 
-	data, err := os.ReadFile(file) //nolint:gosec // file path is from controlled source
-	if err != nil {
-		return fmt.Errorf("failed to read file: %w", err)
-	}
+	for _, file := range files {
+		d.log.WithField("file", file).Debug("Reading data file")
 
-	var dataConfig DataConfig
-	if err := yaml.Unmarshal(data, &dataConfig); err != nil {
-		return fmt.Errorf("failed to parse yaml: %w", err)
-	}
+		data, err := os.ReadFile(file) //nolint:gosec // file path is from controlled source
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %s: %w", file, err)
+		}
 
-	// Extract table name from filename
-	tableName := filepath.Base(file)
-	tableName = tableName[:len(tableName)-len(filepath.Ext(tableName))]
+		var dataConfig DataConfig
+		if err := yaml.Unmarshal(data, &dataConfig); err != nil {
+			return nil, fmt.Errorf("failed to parse yaml %s: %w", file, err)
+		}
 
-	for _, url := range dataConfig.URLs {
-		d.log.WithFields(logrus.Fields{
-			"url":   url,
-			"table": tableName,
-		}).Debug("Ingesting parquet file")
+		// Extract table name from filename
+		tableName := filepath.Base(file)
+		tableName = tableName[:len(tableName)-len(filepath.Ext(tableName))]
 
-		if err := d.ingestParquet(ctx, conn, url, tableName, dataConfig.NetworkColumn, network); err != nil {
-			return fmt.Errorf("failed to ingest %s: %w", url, err)
+		// Add each URL as a work item
+		for _, url := range dataConfig.URLs {
+			workItems = append(workItems, WorkItem{
+				URL:           url,
+				TableName:     tableName,
+				NetworkColumn: dataConfig.NetworkColumn,
+				Network:       network,
+			})
 		}
 	}
 
-	return nil
+	d.log.WithField("total_urls", len(workItems)).Info("Collected all work items")
+	return workItems, nil
+}
+
+// worker processes work items from the channel
+func (d *dataLoader) worker(ctx context.Context, id int, conn driver.Conn, workChan <-chan WorkItem) error {
+	d.log.WithField("worker_id", id).Debug("Worker started")
+
+	for {
+		select {
+		case <-ctx.Done():
+			d.log.WithField("worker_id", id).Debug("Worker stopped due to context cancellation")
+			return ctx.Err()
+		case item, ok := <-workChan:
+			if !ok {
+				d.log.WithField("worker_id", id).Debug("Worker finished - no more work")
+				return nil
+			}
+
+			d.log.WithFields(logrus.Fields{
+				"worker_id": id,
+				"url":       item.URL,
+				"table":     item.TableName,
+			}).Debug("Worker processing URL")
+
+			if err := d.ingestParquet(ctx, conn, item.URL, item.TableName, item.NetworkColumn, item.Network); err != nil {
+				return fmt.Errorf("worker %d failed to ingest %s: %w", id, item.URL, err)
+			}
+		}
+	}
 }
 
 func (d *dataLoader) ingestParquet(ctx context.Context, conn driver.Conn, url, tableName, networkColumn, network string) error {


### PR DESCRIPTION
- Add golang.org/x/sync dependency for errgroup
- Refactor data loader to use worker pool pattern with 10 concurrent workers
- Separate work collection and processing phases for better organization
- Improve performance when downloading multiple parquet files