### PR TITLE
refactor: rename int_xatu_nodes model to follow time window naming convention

### DIFF
--- a/migrations/005_active_nodes.down.sql
+++ b/migrations/005_active_nodes.down.sql
@@ -1,2 +1,2 @@
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_xatu_nodes__active ON CLUSTER '{cluster}';
-DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_xatu_nodes__active_local ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_xatu_nodes__24h ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS `${NETWORK_NAME}`.int_xatu_nodes__24h_local ON CLUSTER '{cluster}';

--- a/migrations/005_active_nodes.up.sql
+++ b/migrations/005_active_nodes.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `${NETWORK_NAME}`.int_xatu_nodes__active_local on cluster '{cluster}' (
+CREATE TABLE `${NETWORK_NAME}`.int_xatu_nodes__24h_local on cluster '{cluster}' (
     `updated_date_time` DateTime COMMENT 'Timestamp when the record was last updated' CODEC(DoubleDelta, ZSTD(1)),
     `last_seen_date_time` DateTime COMMENT 'Timestamp when the node was last seen' CODEC(DoubleDelta, ZSTD(1)),
     `username` String COMMENT 'Username of the node' CODEC(ZSTD(1)),
@@ -20,9 +20,9 @@ CREATE TABLE `${NETWORK_NAME}`.int_xatu_nodes__active_local on cluster '{cluster
 ) ORDER BY
     (`meta_client_name`) COMMENT 'Active nodes for the network';
 
-CREATE TABLE `${NETWORK_NAME}`.int_xatu_nodes__active ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_xatu_nodes__active_local ENGINE = Distributed(
+CREATE TABLE `${NETWORK_NAME}`.int_xatu_nodes__24h ON CLUSTER '{cluster}' AS `${NETWORK_NAME}`.int_xatu_nodes__24h_local ENGINE = Distributed(
     '{cluster}',
     '${NETWORK_NAME}',
-    int_xatu_nodes__active_local,
+    int_xatu_nodes__24h_local,
     cityHash64(`meta_client_name`)
 );

--- a/models/transformations/int_xatu_nodes__24h.sql
+++ b/models/transformations/int_xatu_nodes__24h.sql
@@ -1,5 +1,5 @@
 ---
-table: int_xatu_nodes__active
+table: int_xatu_nodes__24h
 interval:
   max: 60
 schedules:
@@ -46,6 +46,6 @@ SELECT
     argMax(meta_consensus_version, slot_start_date_time) AS meta_consensus_version,
     argMax(meta_consensus_implementation, slot_start_date_time) AS meta_consensus_implementation
 FROM `{{ index .dep "{{external}}" "beacon_api_eth_v1_events_block" "database" }}`.`beacon_api_eth_v1_events_block` FINAL
-WHERE slot_start_date_time >= NOW() - INTERVAL '1 HOUR'
+WHERE slot_start_date_time >= NOW() - INTERVAL '24 HOUR'
 GROUP BY meta_client_name
 ORDER BY last_seen_date_time DESC;

--- a/tests/pectra/assertions/int_xatu_nodes__24h.yaml
+++ b/tests/pectra/assertions/int_xatu_nodes__24h.yaml
@@ -3,7 +3,7 @@
     SELECT
       COUNT(*) AS count
     FROM
-      'int_xatu_nodes__active' FINAL
+      'int_xatu_nodes__24h' FINAL
   expected:
     count: 0 # expected as the nodes are in the past
 - name: "Expected admin bounds"
@@ -14,7 +14,7 @@
     FROM
       admin_cbt FINAL
     WHERE
-      table = 'int_xatu_nodes__active'
+      table = 'int_xatu_nodes__24h'
   expected:
     max: "2025-07-15T23:59:59Z"
     min: "2025-07-15T23:58:59Z"


### PR DESCRIPTION
- Rename int_xatu_nodes__active to int_xatu_nodes__24h
- Update time window from 1 hour to 24 hours
- Update all references in migrations and test assertions