### PR TITLE
refactor: migrate module path from savid to ethpandaops organization

### DIFF
--- a/cmd/infra.go
+++ b/cmd/infra.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/savid/xatu-cbt/internal/test"
+	"github.com/ethpandaops/xatu-cbt/internal/test"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/savid/xatu-cbt/internal/actions"
-	"github.com/savid/xatu-cbt/internal/interactive"
+	"github.com/ethpandaops/xatu-cbt/internal/actions"
+	"github.com/ethpandaops/xatu-cbt/internal/interactive"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/savid/xatu-cbt/internal/actions"
+	"github.com/ethpandaops/xatu-cbt/internal/actions"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/show_config.go
+++ b/cmd/show_config.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/savid/xatu-cbt/internal/actions"
+	"github.com/ethpandaops/xatu-cbt/internal/actions"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/savid/xatu-cbt/internal/actions"
+	"github.com/ethpandaops/xatu-cbt/internal/actions"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/savid/xatu-cbt/internal/test"
+	"github.com/ethpandaops/xatu-cbt/internal/test"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/xatu-cbt/main.go
+++ b/cmd/xatu-cbt/main.go
@@ -4,7 +4,7 @@ package main
 import (
 	"os"
 
-	"github.com/savid/xatu-cbt/cmd"
+	"github.com/ethpandaops/xatu-cbt/cmd"
 )
 
 func main() {

--- a/cmd/xatu-cbt/tui.go
+++ b/cmd/xatu-cbt/tui.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/savid/xatu-cbt/cmd"
-	"github.com/savid/xatu-cbt/internal/actions"
-	"github.com/savid/xatu-cbt/internal/interactive"
-	"github.com/savid/xatu-cbt/internal/test"
+	"github.com/ethpandaops/xatu-cbt/cmd"
+	"github.com/ethpandaops/xatu-cbt/internal/actions"
+	"github.com/ethpandaops/xatu-cbt/internal/interactive"
+	"github.com/ethpandaops/xatu-cbt/internal/test"
 )
 
 func runInteractive() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/savid/xatu-cbt
+module github.com/ethpandaops/xatu-cbt
 
 go 1.24.6
 

--- a/internal/actions/config.go
+++ b/internal/actions/config.go
@@ -3,7 +3,7 @@ package actions
 import (
 	"fmt"
 
-	"github.com/savid/xatu-cbt/internal/config"
+	"github.com/ethpandaops/xatu-cbt/internal/config"
 )
 
 // ShowConfig displays the current configuration

--- a/internal/actions/setup.go
+++ b/internal/actions/setup.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/savid/xatu-cbt/internal/clickhouse"
-	"github.com/savid/xatu-cbt/internal/config"
-	"github.com/savid/xatu-cbt/internal/migrations"
+	"github.com/ethpandaops/xatu-cbt/internal/clickhouse"
+	"github.com/ethpandaops/xatu-cbt/internal/config"
+	"github.com/ethpandaops/xatu-cbt/internal/migrations"
 )
 
 // Setup validates config and sets up ClickHouse database for the configured network

--- a/internal/actions/teardown.go
+++ b/internal/actions/teardown.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/savid/xatu-cbt/internal/clickhouse"
-	"github.com/savid/xatu-cbt/internal/config"
+	"github.com/ethpandaops/xatu-cbt/internal/clickhouse"
+	"github.com/ethpandaops/xatu-cbt/internal/config"
 )
 
 // Teardown validates config and drops the ClickHouse database for the configured network
@@ -84,10 +84,10 @@ func Teardown(isInteractive, skipConfirm bool) error { //nolint:gocyclo // Compl
 
 	// Get all _local tables in the database
 	tablesQuery := fmt.Sprintf(`
-		SELECT name 
-		FROM system.tables 
-		WHERE database = '%s' 
-		AND name LIKE '%%_local' 
+		SELECT name
+		FROM system.tables
+		WHERE database = '%s'
+		AND name LIKE '%%_local'
 		AND name != 'schema_migrations_local'
 		ORDER BY name
 	`, cfg.Network)

--- a/internal/clickhouse/client.go
+++ b/internal/clickhouse/client.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/savid/xatu-cbt/internal/config"
+	"github.com/ethpandaops/xatu-cbt/internal/config"
 )
 
 // Connect establishes a connection to ClickHouse using native protocol

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -8,10 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ethpandaops/xatu-cbt/internal/config"
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/clickhouse" // clickhouse driver for migrations
 	_ "github.com/golang-migrate/migrate/v4/source/file"         // file source driver for migrations
-	"github.com/savid/xatu-cbt/internal/config"
 )
 
 // PrepareAndRun prepares migration files by substituting network name and runs migrations

--- a/internal/test/assertion_runner.go
+++ b/internal/test/assertion_runner.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/savid/xatu-cbt/internal/clickhouse"
-	"github.com/savid/xatu-cbt/internal/config"
+	"github.com/ethpandaops/xatu-cbt/internal/clickhouse"
+	"github.com/ethpandaops/xatu-cbt/internal/config"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )

--- a/internal/test/data_loader.go
+++ b/internal/test/data_loader.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/savid/xatu-cbt/internal/clickhouse"
-	"github.com/savid/xatu-cbt/internal/config"
+	"github.com/ethpandaops/xatu-cbt/internal/clickhouse"
+	"github.com/ethpandaops/xatu-cbt/internal/config"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
@@ -192,14 +192,14 @@ func (d *dataLoader) ingestParquet(ctx context.Context, conn driver.Conn, url, t
 		// Use REPLACE to override the network column value during insertion
 		// This avoids issues with updating key columns
 		query = fmt.Sprintf(`
-			INSERT INTO default.%s 
+			INSERT INTO default.%s
 			SELECT * REPLACE ('%s' AS %s)
 			FROM url('%s', 'Parquet')
 		`, tableName, network, networkColumn, url)
 	} else {
 		// Standard insert without modification
 		query = fmt.Sprintf(`
-			INSERT INTO default.%s 
+			INSERT INTO default.%s
 			SELECT * FROM url('%s', 'Parquet')
 		`, tableName, url)
 	}


### PR DESCRIPTION
Fixes:

```
> go get github.com/ethpandaops/xatu-cbt
go: downloading github.com/ethpandaops/xatu-cbt v0.0.0-20250904073050-7b31499c0f7e
go: github.com/ethpandaops/xatu-cbt@v0.0.0-20250904073050-7b31499c0f7e requires go >= 1.24.6; switching to go1.24.7
go: downloading go1.24.7 (darwin/arm64)
go: github.com/ethpandaops/xatu-cbt@upgrade (v0.0.0-20250904073050-7b31499c0f7e) requires github.com/ethpandaops/xatu-cbt@v0.0.0-20250904073050-7b31499c0f7e: parsing go.mod:
        module declares its path as: github.com/savid/xatu-cbt
                but was required as: github.com/ethpandaops/xatu-cbt
```