### PR TITLE
chore: adjust model intervals and schedules

### DIFF
--- a/models/transformations/fct_attestation_correctness_by_validator_canonical.sql
+++ b/models/transformations/fct_attestation_correctness_by_validator_canonical.sql
@@ -4,6 +4,7 @@ interval:
   max: 384
 schedules:
   forwardfill: "@every 30s"
+  backfill: "@every 1m"
 tags:
   - slot
   - attestation

--- a/models/transformations/fct_attestation_correctness_by_validator_head.sql
+++ b/models/transformations/fct_attestation_correctness_by_validator_head.sql
@@ -4,6 +4,7 @@ interval:
   max: 384
 schedules:
   forwardfill: "@every 5s"
+  backfill: "@every 30s"
 tags:
   - slot
   - attestation

--- a/models/transformations/fct_attestation_correctness_canonical.sql
+++ b/models/transformations/fct_attestation_correctness_canonical.sql
@@ -4,6 +4,7 @@ interval:
   max: 384
 schedules:
   forwardfill: "@every 30s"
+  backfill: "@every 1m"
 tags:
   - slot
   - attestation

--- a/models/transformations/fct_attestation_correctness_head.sql
+++ b/models/transformations/fct_attestation_correctness_head.sql
@@ -4,6 +4,7 @@ interval:
   max: 384
 schedules:
   forwardfill: "@every 5s"
+  backfill: "@every 30s"
 tags:
   - slot
   - attestation

--- a/models/transformations/fct_block.sql
+++ b/models/transformations/fct_block.sql
@@ -1,7 +1,7 @@
 ---
 table: fct_block
 interval:
-  max: 500000
+  max: 5000
 schedules:
   forwardfill: "@every 30s"
   backfill: "@every 1m"

--- a/models/transformations/fct_block_proposer.sql
+++ b/models/transformations/fct_block_proposer.sql
@@ -1,7 +1,7 @@
 ---
 table: fct_block_proposer
 interval:
-  max: 500000
+  max: 5000
 schedules:
   forwardfill: "@every 30s"
   backfill: "@every 1m"

--- a/models/transformations/int_attestation_attested_canonical.sql
+++ b/models/transformations/int_attestation_attested_canonical.sql
@@ -4,6 +4,7 @@ interval:
   max: 384
 schedules:
   forwardfill: "@every 30s"
+  backfill: "@every 1m"
 tags:
   - slot
   - attestation

--- a/models/transformations/int_attestation_attested_head.sql
+++ b/models/transformations/int_attestation_attested_head.sql
@@ -4,6 +4,7 @@ interval:
   max: 384
 schedules:
   forwardfill: "@every 5s"
+  backfill: "@every 30s"
 tags:
   - slot
   - attestation

--- a/models/transformations/int_attestation_first_seen.sql
+++ b/models/transformations/int_attestation_first_seen.sql
@@ -4,6 +4,7 @@ interval:
   max: 384
 schedules:
   forwardfill: "@every 5s"
+  backfill: "@every 30s"
 tags:
   - slot
   - attestation

--- a/models/transformations/int_block_blob_count_head.sql
+++ b/models/transformations/int_block_blob_count_head.sql
@@ -1,10 +1,10 @@
 ---
 table: int_block_blob_count_head
 interval:
-  max: 500000
+  max: 5000
 schedules:
   forwardfill: "@every 5s"
-  backfill: "@every 1m"
+  backfill: "@every 30s"
 tags:
   - slot
   - block

--- a/models/transformations/int_block_canonical.sql
+++ b/models/transformations/int_block_canonical.sql
@@ -1,7 +1,7 @@
 ---
 table: int_block_canonical
 interval:
-  max: 500000
+  max: 5000
 schedules:
   forwardfill: "@every 30s"
   backfill: "@every 1m"

--- a/models/transformations/int_block_first_seen_by_node.sql
+++ b/models/transformations/int_block_first_seen_by_node.sql
@@ -1,10 +1,10 @@
 ---
 table: int_block_first_seen_by_node
 interval:
-  max: 500000
+  max: 5000
 schedules:
   forwardfill: "@every 5s"
-  backfill: "@every 1m"
+  backfill: "@every 30s"
 tags:
   - slot
   - block

--- a/models/transformations/int_block_head.sql
+++ b/models/transformations/int_block_head.sql
@@ -1,10 +1,10 @@
 ---
 table: int_block_head
 interval:
-  max: 500000
+  max: 5000
 schedules:
   forwardfill: "@every 5s"
-  backfill: "@every 1m"
+  backfill: "@every 30s"
 tags:
   - slot
   - block

--- a/models/transformations/int_block_proposer_canonical.sql
+++ b/models/transformations/int_block_proposer_canonical.sql
@@ -1,7 +1,7 @@
 ---
 table: int_block_proposer_canonical
 interval:
-  max: 500000
+  max: 5000
 schedules:
   forwardfill: "@every 30s"
   backfill: "@every 1m"

--- a/models/transformations/int_block_proposer_head.sql
+++ b/models/transformations/int_block_proposer_head.sql
@@ -1,10 +1,10 @@
 ---
 table: int_block_proposer_head
 interval:
-  max: 500000
+  max: 5000
 schedules:
   forwardfill: "@every 5s"
-  backfill: "@every 1m"
+  backfill: "@every 30s"
 tags:
   - slot
   - block


### PR DESCRIPTION
- Reduce max interval from 500000 to 5000 for block-related models
- Add schedules to attestation correctness models