### PR TITLE
perf: optimize model performance with date filters and batch intervals

### DIFF
--- a/models/external/beacon_api_eth_v1_events_attestation.sql
+++ b/models/external/beacon_api_eth_v1_events_attestation.sql
@@ -13,6 +13,10 @@ SELECT
 FROM `default`.`{{ .self.table }}`
 WHERE 
     meta_network_name = '{{ .self.database }}'
+-- Hardcoded min date for mainnet to avoid querying the full table.
+{{ if eq .self.database "mainnet" }}
+    AND slot_start_date_time > '2025-06-01 00:00:00'
+{{ end }}
 {{ if .cache.is_incremental_scan }}
     AND (
       slot_start_date_time <= fromUnixTimestamp({{ .cache.previous_min }})

--- a/models/external/beacon_api_eth_v1_events_attestation.sql
+++ b/models/external/beacon_api_eth_v1_events_attestation.sql
@@ -13,13 +13,14 @@ SELECT
 FROM `default`.`{{ .self.table }}`
 WHERE 
     meta_network_name = '{{ .self.database }}'
--- Hardcoded min date for mainnet to avoid querying the full table.
-{{ if eq .self.database "mainnet" }}
-    AND slot_start_date_time > '2025-06-01 00:00:00'
-{{ end }}
 {{ if .cache.is_incremental_scan }}
     AND (
       slot_start_date_time <= fromUnixTimestamp({{ .cache.previous_min }})
       OR slot_start_date_time >= fromUnixTimestamp({{ .cache.previous_max }})
     )
+{{ else }}
+    -- Hardcoded min date for mainnet to avoid querying the full table on full scans.
+    {{ if eq .self.database "mainnet" }}
+    AND slot_start_date_time > '2025-06-01 00:00:00'
+    {{ end }}
 {{ end }}

--- a/models/external/libp2p_gossipsub_beacon_attestation.sql
+++ b/models/external/libp2p_gossipsub_beacon_attestation.sql
@@ -13,6 +13,10 @@ SELECT
 FROM `default`.`{{ .self.table }}`
 WHERE 
     meta_network_name = '{{ .self.database }}'
+-- Hardcoded min date for mainnet to avoid querying the full table.
+{{ if eq .self.database "mainnet" }}
+    AND slot_start_date_time > '2025-06-01 00:00:00'
+{{ end }}
 {{ if .cache.is_incremental_scan }}
     AND (
       slot_start_date_time <= fromUnixTimestamp({{ .cache.previous_min }})

--- a/models/external/libp2p_gossipsub_beacon_attestation.sql
+++ b/models/external/libp2p_gossipsub_beacon_attestation.sql
@@ -13,13 +13,14 @@ SELECT
 FROM `default`.`{{ .self.table }}`
 WHERE 
     meta_network_name = '{{ .self.database }}'
--- Hardcoded min date for mainnet to avoid querying the full table.
-{{ if eq .self.database "mainnet" }}
-    AND slot_start_date_time > '2025-06-01 00:00:00'
-{{ end }}
 {{ if .cache.is_incremental_scan }}
     AND (
       slot_start_date_time <= fromUnixTimestamp({{ .cache.previous_min }})
       OR slot_start_date_time >= fromUnixTimestamp({{ .cache.previous_max }})
     )
+{{ else }}
+    -- Hardcoded min date for mainnet to avoid querying the full table on full scans.
+    {{ if eq .self.database "mainnet" }}
+    AND slot_start_date_time > '2025-06-01 00:00:00'
+    {{ end }}
 {{ end }}

--- a/models/transformations/fct_mev_bid_count_by_relay.sql
+++ b/models/transformations/fct_mev_bid_count_by_relay.sql
@@ -1,7 +1,7 @@
 ---
 table: fct_mev_bid_count_by_relay
 interval:
-  max: 5000
+  max: 384
 schedules:
   forwardfill: "@every 5s"
   backfill: "@every 1m"

--- a/models/transformations/fct_mev_bid_value_by_builder.sql
+++ b/models/transformations/fct_mev_bid_value_by_builder.sql
@@ -1,7 +1,7 @@
 ---
 table: fct_mev_bid_value_by_builder
 interval:
-  max: 5000
+  max: 384
 schedules:
   forwardfill: "@every 5s"
   backfill: "@every 1m"

--- a/models/transformations/int_block_mev_canonical.sql
+++ b/models/transformations/int_block_mev_canonical.sql
@@ -1,7 +1,7 @@
 ---
 table: int_block_mev_canonical
 interval:
-  max: 50000
+  max: 384
 schedules:
   forwardfill: "@every 30s"
   backfill: "@every 1m"

--- a/models/transformations/int_block_mev_head.sql
+++ b/models/transformations/int_block_mev_head.sql
@@ -1,7 +1,7 @@
 ---
 table: int_block_mev_head
 interval:
-  max: 50000
+  max: 384
 schedules:
   forwardfill: "@every 5s"
   backfill: "@every 1m"


### PR DESCRIPTION
- Add mainnet date filters to attestation external models to reduce scan range
- Reduce max intervals from 5000/50000 to 384 for MEV transformation models