### PR TITLE
perf: optimize attestation model scans for mainnet and reduce MEV interval

### DIFF
--- a/models/external/beacon_api_eth_v1_events_attestation.sql
+++ b/models/external/beacon_api_eth_v1_events_attestation.sql
@@ -4,8 +4,17 @@ cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
 ---
-SELECT 
+SELECT
+    -- Hardcoded min date for mainnet to avoid querying the full table on full scans.
+    {{ if eq .self.database "mainnet" }}
+        {{ if .cache.is_incremental_scan }}
+          '{{ .cache.previous_min }}' as min,
+        {{ else }}
+          toUnixTimestamp(min(slot_start_date_time)) as min,
+        {{ end }}
+    {{ else }}
     toUnixTimestamp(min(slot_start_date_time)) as min,
+    {{ end }}
     toUnixTimestamp(max(slot_start_date_time)) as max
 -- Use the default database as predicate pushdown does not work with views.
 -- This gives 2-3x the performance.
@@ -13,14 +22,17 @@ SELECT
 FROM `default`.`{{ .self.table }}`
 WHERE 
     meta_network_name = '{{ .self.database }}'
-{{ if .cache.is_incremental_scan }}
+
+-- Hardcoded min date for mainnet to avoid querying the full table on full scans.
+{{ if eq .self.database "mainnet" }}
+  {{ if .cache.is_incremental_scan }}
+    AND slot_start_date_time >= fromUnixTimestamp({{ .cache.previous_max }})
+  {{ else }}
+    AND slot_start_date_time > '2025-06-01 00:00:00'
+  {{ end }}
+{{ else if .cache.is_incremental_scan }}
     AND (
       slot_start_date_time <= fromUnixTimestamp({{ .cache.previous_min }})
       OR slot_start_date_time >= fromUnixTimestamp({{ .cache.previous_max }})
     )
-{{ else }}
-    -- Hardcoded min date for mainnet to avoid querying the full table on full scans.
-    {{ if eq .self.database "mainnet" }}
-    AND slot_start_date_time > '2025-06-01 00:00:00'
-    {{ end }}
 {{ end }}

--- a/models/external/libp2p_gossipsub_beacon_attestation.sql
+++ b/models/external/libp2p_gossipsub_beacon_attestation.sql
@@ -4,8 +4,17 @@ cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
 ---
-SELECT 
+SELECT
+    -- Hardcoded min date for mainnet to avoid querying the full table on full scans.
+    {{ if eq .self.database "mainnet" }}
+        {{ if .cache.is_incremental_scan }}
+          '{{ .cache.previous_min }}' as min,
+        {{ else }}
+          toUnixTimestamp(min(slot_start_date_time)) as min,
+        {{ end }}
+    {{ else }}
     toUnixTimestamp(min(slot_start_date_time)) as min,
+    {{ end }}
     toUnixTimestamp(max(slot_start_date_time)) as max
 -- Use the default database as predicate pushdown does not work with views.
 -- This gives 2-3x the performance.
@@ -13,14 +22,17 @@ SELECT
 FROM `default`.`{{ .self.table }}`
 WHERE 
     meta_network_name = '{{ .self.database }}'
-{{ if .cache.is_incremental_scan }}
+
+-- Hardcoded min date for mainnet to avoid querying the full table on full scans.
+{{ if eq .self.database "mainnet" }}
+  {{ if .cache.is_incremental_scan }}
+    AND slot_start_date_time >= fromUnixTimestamp({{ .cache.previous_max }})
+  {{ else }}
+    AND slot_start_date_time > '2025-06-01 00:00:00'
+  {{ end }}
+{{ else if .cache.is_incremental_scan }}
     AND (
       slot_start_date_time <= fromUnixTimestamp({{ .cache.previous_min }})
       OR slot_start_date_time >= fromUnixTimestamp({{ .cache.previous_max }})
     )
-{{ else }}
-    -- Hardcoded min date for mainnet to avoid querying the full table on full scans.
-    {{ if eq .self.database "mainnet" }}
-    AND slot_start_date_time > '2025-06-01 00:00:00'
-    {{ end }}
 {{ end }}

--- a/models/transformations/fct_block_mev.sql
+++ b/models/transformations/fct_block_mev.sql
@@ -1,7 +1,7 @@
 ---
 table: fct_block_mev
 interval:
-  max: 50000
+  max: 384
 schedules:
   forwardfill: "@every 30s"
   backfill: "@every 1m"


### PR DESCRIPTION

- Use cached min values for incremental scans to avoid re-querying
- Apply hardcoded date filter for mainnet full scans
- Switch to forward-only scanning for mainnet incremental scans
- Reduce fct_block_mev interval from 50000 to 384 (2 epochs)