### PR TITLE
perf: add date bounds filtering to MEV transformation models

### DIFF
--- a/models/transformations/fct_mev_bid_count_by_relay.sql
+++ b/models/transformations/fct_mev_bid_count_by_relay.sql
@@ -23,4 +23,5 @@ SELECT
     relay_name,
     count(*) AS bid_total
 FROM `{{ index .dep "{{external}}" "mev_relay_bid_trace" "database" }}`.`mev_relay_bid_trace` FINAL
+WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
 GROUP BY slot_start_date_time, slot, epoch, epoch_start_date_time, relay_name

--- a/models/transformations/fct_mev_bid_value_by_builder.sql
+++ b/models/transformations/fct_mev_bid_value_by_builder.sql
@@ -25,6 +25,7 @@ WITH max_value AS (
       block_hash,
       max(value) AS transaction_value
   FROM `{{ index .dep "{{external}}" "mev_relay_bid_trace" "database" }}`.`mev_relay_bid_trace` FINAL
+  WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
   GROUP BY slot_start_date_time, slot, epoch,  epoch_start_date_time,  block_hash
 )
 


### PR DESCRIPTION
Add slot_start_date_time filtering using bounds to reduce data scanned in:
- fct_mev_bid_count_by_relay
- fct_mev_bid_value_by_builder