### PR TITLE
fix: include block_root and blob_index in GROUP BY for proper blob de…

### DIFF
--- a/models/transformations/fct_block_blob_first_seen_by_node.sql
+++ b/models/transformations/fct_block_blob_first_seen_by_node.sql
@@ -44,8 +44,8 @@ SELECT
     argMin(epoch, propagation_slot_start_diff) AS epoch,
     argMin(epoch_start_date_time, propagation_slot_start_diff) AS epoch_start_date_time,
     MIN(propagation_slot_start_diff) as seen_slot_start_diff,
-    argMin(block_root, propagation_slot_start_diff) AS block_root,
-    argMin(blob_index, propagation_slot_start_diff) AS blob_index,
+    block_root,
+    blob_index,
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
             splitByChar('/', meta_client_name)[2]
@@ -76,4 +76,4 @@ SELECT
     argMin(meta_consensus_version, propagation_slot_start_diff) AS meta_consensus_version,
     argMin(meta_consensus_implementation, propagation_slot_start_diff) AS meta_consensus_implementation
 FROM combined_events
-GROUP BY slot_start_date_time, meta_client_name
+GROUP BY slot_start_date_time, meta_client_name, block_root, blob_index

--- a/tests/pectra/assertions/fct_block_blob_first_seen_by_node.yaml
+++ b/tests/pectra/assertions/fct_block_blob_first_seen_by_node.yaml
@@ -7,7 +7,7 @@
     FROM
       fct_block_blob_first_seen_by_node FINAL
   expected:
-    count: 1050
+    count: 8190
     min: "2025-07-15T08:34:35Z"
     max: "2025-07-15T08:37:59Z"
 - name: "Expected admin bounds"


### PR DESCRIPTION
…duplication

- Remove argMin for block_root and blob_index fields
- Add block_root and blob_index to GROUP BY clause
- Update test expectations to reflect correct deduplication count