### PR TITLE
fix: use source field for entity identification in block proposer entity model

### DIFF
--- a/models/transformations/fct_block_proposer_entity.sql
+++ b/models/transformations/fct_block_proposer_entity.sql
@@ -22,9 +22,9 @@ SELECT
     bph.slot_start_date_time,
     bph.epoch,
     bph.epoch_start_date_time,
-    dn.name as entity
+    dn.source as entity
 FROM `{{ index .dep "{{transformation}}" "fct_block_proposer_head" "database" }}`.`fct_block_proposer_head` AS bph FINAL
 GLOBAL LEFT JOIN `{{ index .dep "{{transformation}}" "fct_block_proposer_head" "database" }}`.`dim_node` AS dn FINAL
     ON bph.proposer_validator_index = dn.validator_index
-    AND dn.source = 'entity'
 WHERE bph.slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+SETTINGS join_use_nulls = 1;


### PR DESCRIPTION
- Change entity field from name to source
- Remove entity source filter from join condition
- Add join_use_nulls setting for proper null handling