### PR TITLE
chore: increase lag from 12 to 24 seconds across external 

### DIFF
--- a/models/external/beacon_api_eth_v1_beacon_committee.sql
+++ b/models/external/beacon_api_eth_v1_beacon_committee.sql
@@ -3,7 +3,7 @@ table: beacon_api_eth_v1_beacon_committee
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/beacon_api_eth_v1_events_attestation.sql
+++ b/models/external/beacon_api_eth_v1_events_attestation.sql
@@ -3,7 +3,7 @@ table: beacon_api_eth_v1_events_attestation
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT
     -- Hardcoded min date for mainnet to avoid querying the full table on full scans.

--- a/models/external/beacon_api_eth_v1_events_blob_sidecar.sql
+++ b/models/external/beacon_api_eth_v1_events_blob_sidecar.sql
@@ -3,7 +3,7 @@ table: beacon_api_eth_v1_events_blob_sidecar
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/beacon_api_eth_v1_events_block.sql
+++ b/models/external/beacon_api_eth_v1_events_block.sql
@@ -3,7 +3,7 @@ table: beacon_api_eth_v1_events_block
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/beacon_api_eth_v1_events_block_gossip.sql
+++ b/models/external/beacon_api_eth_v1_events_block_gossip.sql
@@ -3,7 +3,7 @@ table: beacon_api_eth_v1_events_block_gossip
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/beacon_api_eth_v1_events_data_column_sidecar.sql
+++ b/models/external/beacon_api_eth_v1_events_data_column_sidecar.sql
@@ -3,7 +3,7 @@ table: beacon_api_eth_v1_events_data_column_sidecar
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/beacon_api_eth_v1_events_head.sql
+++ b/models/external/beacon_api_eth_v1_events_head.sql
@@ -3,7 +3,7 @@ table: beacon_api_eth_v1_events_head
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/beacon_api_eth_v1_proposer_duty.sql
+++ b/models/external/beacon_api_eth_v1_proposer_duty.sql
@@ -3,7 +3,7 @@ table: beacon_api_eth_v1_proposer_duty
 cache:
   incremental_scan_interval: 30s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/beacon_api_eth_v2_beacon_block.sql
+++ b/models/external/beacon_api_eth_v2_beacon_block.sql
@@ -3,7 +3,7 @@ table: beacon_api_eth_v2_beacon_block
 cache:
   incremental_scan_interval: 30s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/beacon_api_eth_v3_validator_block.sql
+++ b/models/external/beacon_api_eth_v3_validator_block.sql
@@ -3,7 +3,7 @@ table: beacon_api_eth_v3_validator_block
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 60
+lag: 24
 ---
 SELECT
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/canonical_beacon_blob_sidecar.sql
+++ b/models/external/canonical_beacon_blob_sidecar.sql
@@ -3,6 +3,7 @@ table: canonical_beacon_blob_sidecar
 cache:
   incremental_scan_interval: 1m
   full_scan_interval: 24h
+lag: 384
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/canonical_beacon_block.sql
+++ b/models/external/canonical_beacon_block.sql
@@ -3,6 +3,7 @@ table: canonical_beacon_block
 cache:
   incremental_scan_interval: 1m
   full_scan_interval: 24h
+lag: 384
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/canonical_beacon_committee.sql
+++ b/models/external/canonical_beacon_committee.sql
@@ -3,6 +3,7 @@ table: canonical_beacon_committee
 cache:
   incremental_scan_interval: 1m
   full_scan_interval: 24h
+lag: 384
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/canonical_beacon_elaborated_attestation.sql
+++ b/models/external/canonical_beacon_elaborated_attestation.sql
@@ -3,6 +3,7 @@ table: canonical_beacon_elaborated_attestation
 cache:
   incremental_scan_interval: 1m
   full_scan_interval: 24h
+lag: 384
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/canonical_beacon_proposer_duty.sql
+++ b/models/external/canonical_beacon_proposer_duty.sql
@@ -3,6 +3,7 @@ table: canonical_beacon_proposer_duty
 cache:
   incremental_scan_interval: 2m
   full_scan_interval: 24h
+lag: 384
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/canonical_execution_balance_diffs.sql
+++ b/models/external/canonical_execution_balance_diffs.sql
@@ -3,6 +3,7 @@ table: canonical_execution_balance_diffs
 cache:
   incremental_scan_interval: 1m
   full_scan_interval: 24h
+lag: 384
 ---
 SELECT 
     min(block_number) as min,

--- a/models/external/canonical_execution_balance_reads.sql
+++ b/models/external/canonical_execution_balance_reads.sql
@@ -3,6 +3,7 @@ table: canonical_execution_balance_reads
 cache:
   incremental_scan_interval: 1m
   full_scan_interval: 24h
+lag: 384
 ---
 SELECT 
     min(block_number) as min,

--- a/models/external/canonical_execution_contracts.sql
+++ b/models/external/canonical_execution_contracts.sql
@@ -3,6 +3,7 @@ table: canonical_execution_contracts
 cache:
   incremental_scan_interval: 1m
   full_scan_interval: 24h
+lag: 384
 ---
 SELECT 
     min(block_number) as min,

--- a/models/external/canonical_execution_nonce_diffs.sql
+++ b/models/external/canonical_execution_nonce_diffs.sql
@@ -3,6 +3,7 @@ table: canonical_execution_nonce_diffs
 cache:
   incremental_scan_interval: 1m
   full_scan_interval: 24h
+lag: 384
 ---
 SELECT 
     min(block_number) as min,

--- a/models/external/canonical_execution_nonce_reads.sql
+++ b/models/external/canonical_execution_nonce_reads.sql
@@ -3,6 +3,7 @@ table: canonical_execution_nonce_reads
 cache:
   incremental_scan_interval: 1m
   full_scan_interval: 24h
+lag: 384
 ---
 SELECT 
     min(block_number) as min,

--- a/models/external/canonical_execution_storage_diffs.sql
+++ b/models/external/canonical_execution_storage_diffs.sql
@@ -3,6 +3,7 @@ table: canonical_execution_storage_diffs
 cache:
   incremental_scan_interval: 1m
   full_scan_interval: 24h
+lag: 384
 ---
 SELECT 
     min(block_number) as min,

--- a/models/external/canonical_execution_storage_reads.sql
+++ b/models/external/canonical_execution_storage_reads.sql
@@ -3,6 +3,7 @@ table: canonical_execution_storage_reads
 cache:
   incremental_scan_interval: 1m
   full_scan_interval: 24h
+lag: 384
 ---
 SELECT 
     min(block_number) as min,

--- a/models/external/libp2p_gossipsub_beacon_attestation.sql
+++ b/models/external/libp2p_gossipsub_beacon_attestation.sql
@@ -3,7 +3,7 @@ table: libp2p_gossipsub_beacon_attestation
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT
     -- Hardcoded min date for mainnet to avoid querying the full table on full scans.

--- a/models/external/libp2p_gossipsub_beacon_block.sql
+++ b/models/external/libp2p_gossipsub_beacon_block.sql
@@ -3,7 +3,7 @@ table: libp2p_gossipsub_beacon_block
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/libp2p_gossipsub_blob_sidecar.sql
+++ b/models/external/libp2p_gossipsub_blob_sidecar.sql
@@ -3,7 +3,7 @@ table: libp2p_gossipsub_blob_sidecar
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/libp2p_gossipsub_data_column_sidecar.sql
+++ b/models/external/libp2p_gossipsub_data_column_sidecar.sql
@@ -3,7 +3,7 @@ table: libp2p_gossipsub_data_column_sidecar
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/mev_relay_bid_trace.sql
+++ b/models/external/mev_relay_bid_trace.sql
@@ -3,7 +3,7 @@ table: mev_relay_bid_trace
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/models/external/mev_relay_proposer_payload_delivered.sql
+++ b/models/external/mev_relay_proposer_payload_delivered.sql
@@ -3,7 +3,7 @@ table: mev_relay_proposer_payload_delivered
 cache:
   incremental_scan_interval: 5s
   full_scan_interval: 24h
-lag: 12
+lag: 24
 ---
 SELECT 
     toUnixTimestamp(min(slot_start_date_time)) as min,

--- a/overrides.tests.yaml
+++ b/overrides.tests.yaml
@@ -38,40 +38,40 @@ models:
         lag: 0
     canonical_beacon_blob_sidecar:
       config:
-        lag: 12
+        lag: 0
     canonical_beacon_block:
       config:
-        lag: 12
+        lag: 0
     canonical_beacon_committee:
       config:
-        lag: 12
+        lag: 0
     canonical_beacon_elaborated_attestation:
       config:
-        lag: 12
+        lag: 0
     canonical_beacon_proposer_duty:
       config:
-        lag: 12
+        lag: 0
     canonical_execution_balance_diffs:
       config:
-        lag: 12
+        lag: 0
     canonical_execution_balance_reads:
       config:
-        lag: 12
+        lag: 0
     canonical_execution_contracts:
       config:
-        lag: 12
+        lag: 0
     canonical_execution_nonce_diffs:
       config:
-        lag: 12
+        lag: 0
     canonical_execution_nonce_reads:
       config:
-        lag: 12
+        lag: 0
     canonical_execution_storage_diffs:
       config:
-        lag: 12
+        lag: 0
     canonical_execution_storage_reads:
       config:
-        lag: 12
+        lag: 0
     libp2p_gossipsub_beacon_attestation:
       config:
         lag: 12

--- a/overrides.tests.yaml
+++ b/overrides.tests.yaml
@@ -6,3 +6,87 @@ models:
       config:
         schedules:
           forwardfill: "@every 5s"
+    beacon_api_eth_v1_beacon_committee:
+      config:
+        lag: 12
+    beacon_api_eth_v1_events_attestation:
+      config:
+        lag: 12
+    beacon_api_eth_v1_events_blob_sidecar:
+      config:
+        lag: 12
+    beacon_api_eth_v1_events_block:
+      config:
+        lag: 12
+    beacon_api_eth_v1_events_block_gossip:
+      config:
+        lag: 12
+    beacon_api_eth_v1_events_data_column_sidecar:
+      config:
+        lag: 12
+    beacon_api_eth_v1_events_head:
+      config:
+        lag: 12
+    beacon_api_eth_v1_proposer_duty:
+      config:
+        lag: 12
+    beacon_api_eth_v2_beacon_block:
+      config:
+        lag: 12
+    beacon_api_eth_v3_validator_block:
+      config:
+        lag: 12
+    canonical_beacon_blob_sidecar:
+      config:
+        lag: 12
+    canonical_beacon_block:
+      config:
+        lag: 12
+    canonical_beacon_committee:
+      config:
+        lag: 12
+    canonical_beacon_elaborated_attestation:
+      config:
+        lag: 12
+    canonical_beacon_proposer_duty:
+      config:
+        lag: 12
+    canonical_execution_balance_diffs:
+      config:
+        lag: 12
+    canonical_execution_balance_reads:
+      config:
+        lag: 12
+    canonical_execution_contracts:
+      config:
+        lag: 12
+    canonical_execution_nonce_diffs:
+      config:
+        lag: 12
+    canonical_execution_nonce_reads:
+      config:
+        lag: 12
+    canonical_execution_storage_diffs:
+      config:
+        lag: 12
+    canonical_execution_storage_reads:
+      config:
+        lag: 12
+    libp2p_gossipsub_beacon_attestation:
+      config:
+        lag: 12
+    libp2p_gossipsub_beacon_block:
+      config:
+        lag: 12
+    libp2p_gossipsub_blob_sidecar:
+      config:
+        lag: 12
+    libp2p_gossipsub_data_column_sidecar:
+      config:
+        lag: 12
+    mev_relay_bid_trace:
+      config:
+        lag: 12
+    mev_relay_proposer_payload_delivered:
+      config:
+        lag: 12


### PR DESCRIPTION
- 384 seconds (1 epoch) for canonical models