### PR TITLE
feat: add corporate node classification support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ fmt:
 proto:
 	@# Load .env file and check NETWORK is set
 	@if [ -f .env ]; then \
-		export $$(grep -v '^#' .env | xargs); \
+		export $$(grep -v '^#' .env | grep -v '^$$' | sed 's/#.*//' | xargs); \
 	fi; \
 	if [ -z "$$NETWORK" ]; then \
 		echo "Error: NETWORK environment variable is not set"; \
@@ -71,7 +71,7 @@ proto:
 	@echo "Removing existing protobuf files..."
 	rm -rf pkg/proto/clickhouse
 	@echo "Generating protobuf files from ClickHouse tables..."
-	@if [ -f .env ]; then export $$(grep -v '^#' .env | xargs); fi; \
+	@if [ -f .env ]; then export $$(grep -v '^#' .env | grep -v '^$$' | sed 's/#.*//' | xargs); fi; \
 	if [ -z "$$NETWORK" ]; then \
 		echo "Error: NETWORK environment variable is not set"; \
 		exit 1; \

--- a/migrations/005_active_nodes.up.sql
+++ b/migrations/005_active_nodes.up.sql
@@ -3,7 +3,7 @@ CREATE TABLE `${NETWORK_NAME}`.fct_node_active_last_24h_local on cluster '{clust
     `last_seen_date_time` DateTime COMMENT 'Timestamp when the node was last seen' CODEC(DoubleDelta, ZSTD(1)),
     `username` String COMMENT 'Username of the node' CODEC(ZSTD(1)),
     `node_id` String COMMENT 'ID of the node' CODEC(ZSTD(1)),
-    `classification` String COMMENT 'Classification of the node, e.g. "individual", "institution", "internal" (aka ethPandaOps) or "unclassified"' CODEC(ZSTD(1)),
+    `classification` String COMMENT 'Classification of the node, e.g. "individual", "corporate", "internal" (aka ethPandaOps) or "unclassified"' CODEC(ZSTD(1)),
     `meta_client_name` LowCardinality(String) COMMENT 'Name of the client',
     `meta_client_version` LowCardinality(String) COMMENT 'Version of the client',
     `meta_client_implementation` LowCardinality(String) COMMENT 'Implementation of the client',

--- a/migrations/006_block_first_seen.up.sql
+++ b/migrations/006_block_first_seen.up.sql
@@ -9,7 +9,7 @@ CREATE TABLE `${NETWORK_NAME}`.fct_block_first_seen_by_node_local on cluster '{c
     `block_root` String COMMENT 'The beacon block root hash' CODEC(ZSTD(1)),
     `username` LowCardinality(String) COMMENT 'Username of the node' CODEC(ZSTD(1)),
     `node_id` String COMMENT 'ID of the node' CODEC(ZSTD(1)),
-    `classification` LowCardinality(String) COMMENT 'Classification of the node, e.g. "individual", "institution", "internal" (aka ethPandaOps) or "unclassified"' CODEC(ZSTD(1)),
+    `classification` LowCardinality(String) COMMENT 'Classification of the node, e.g. "individual", "corporate", "internal" (aka ethPandaOps) or "unclassified"' CODEC(ZSTD(1)),
     `meta_client_name` LowCardinality(String) COMMENT 'Name of the client',
     `meta_client_version` LowCardinality(String) COMMENT 'Version of the client',
     `meta_client_implementation` LowCardinality(String) COMMENT 'Implementation of the client',

--- a/migrations/007_attestation_first_seen.up.sql
+++ b/migrations/007_attestation_first_seen.up.sql
@@ -11,7 +11,7 @@ CREATE TABLE `${NETWORK_NAME}`.int_attestation_first_seen_local on cluster '{clu
     `attesting_validator_committee_index` LowCardinality(String) COMMENT 'The committee index of the attesting validator',
     `username` LowCardinality(String) COMMENT 'Username of the node' CODEC(ZSTD(1)),
     `node_id` String COMMENT 'ID of the node' CODEC(ZSTD(1)),
-    `classification` LowCardinality(String) COMMENT 'Classification of the node, e.g. "individual", "institution", "internal" (aka ethPandaOps) or "unclassified"' CODEC(ZSTD(1)),
+    `classification` LowCardinality(String) COMMENT 'Classification of the node, e.g. "individual", "corporate", "internal" (aka ethPandaOps) or "unclassified"' CODEC(ZSTD(1)),
     `meta_client_name` LowCardinality(String) COMMENT 'Name of the client',
     `meta_client_version` LowCardinality(String) COMMENT 'Version of the client',
     `meta_client_implementation` LowCardinality(String) COMMENT 'Implementation of the client',

--- a/migrations/015_block_blob_first_seen.up.sql
+++ b/migrations/015_block_blob_first_seen.up.sql
@@ -10,7 +10,7 @@ CREATE TABLE `${NETWORK_NAME}`.fct_block_blob_first_seen_by_node_local on cluste
     `blob_index` UInt32 COMMENT 'The blob index' CODEC(DoubleDelta, ZSTD(1)),
     `username` LowCardinality(String) COMMENT 'Username of the node' CODEC(ZSTD(1)),
     `node_id` String COMMENT 'ID of the node' CODEC(ZSTD(1)),
-    `classification` LowCardinality(String) COMMENT 'Classification of the node, e.g. "individual", "institution", "internal" (aka ethPandaOps) or "unclassified"' CODEC(ZSTD(1)),
+    `classification` LowCardinality(String) COMMENT 'Classification of the node, e.g. "individual", "corporate", "internal" (aka ethPandaOps) or "unclassified"' CODEC(ZSTD(1)),
     `meta_client_name` LowCardinality(String) COMMENT 'Name of the client',
     `meta_client_version` LowCardinality(String) COMMENT 'Version of the client',
     `meta_client_implementation` LowCardinality(String) COMMENT 'Implementation of the client',

--- a/models/transformations/fct_block_blob_first_seen_by_node.sql
+++ b/models/transformations/fct_block_blob_first_seen_by_node.sql
@@ -53,11 +53,15 @@ SELECT
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
             splitByChar('/', meta_client_name)[2]
+        WHEN startsWith(meta_client_name, 'corp-') THEN
+            splitByChar('/', meta_client_name)[2]
         ELSE
             'ethpandaops'
     END AS username,
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
+            splitByChar('/', meta_client_name)[3]
+        WHEN startsWith(meta_client_name, 'corp-') THEN
             splitByChar('/', meta_client_name)[3]
         ELSE
             splitByChar('/', meta_client_name)[-1]
@@ -65,6 +69,8 @@ SELECT
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
             'individual'
+        WHEN startsWith(meta_client_name, 'corp-') THEN
+            'corporate'
         WHEN startsWith(meta_client_name, 'ethpandaops') THEN
             'internal'
         ELSE

--- a/models/transformations/fct_block_first_seen_by_node.sql
+++ b/models/transformations/fct_block_first_seen_by_node.sql
@@ -140,11 +140,15 @@ SELECT
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
             splitByChar('/', meta_client_name)[2]
+        WHEN startsWith(meta_client_name, 'corp-') THEN
+            splitByChar('/', meta_client_name)[2]
         ELSE
             'ethpandaops'
     END AS username,
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
+            splitByChar('/', meta_client_name)[3]
+        WHEN startsWith(meta_client_name, 'corp-') THEN
             splitByChar('/', meta_client_name)[3]
         ELSE
             splitByChar('/', meta_client_name)[-1]
@@ -152,6 +156,8 @@ SELECT
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
             'individual'
+        WHEN startsWith(meta_client_name, 'corp-') THEN
+            'corporate'
         WHEN startsWith(meta_client_name, 'ethpandaops') THEN
             'internal'
         ELSE

--- a/models/transformations/fct_node_active_last_24h.sql
+++ b/models/transformations/fct_node_active_last_24h.sql
@@ -19,11 +19,15 @@ SELECT
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
             splitByChar('/', meta_client_name)[2]
+        WHEN startsWith(meta_client_name, 'corp-') THEN
+            splitByChar('/', meta_client_name)[2]
         ELSE
             'ethpandaops'
     END AS username,
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
+            splitByChar('/', meta_client_name)[3]
+        WHEN startsWith(meta_client_name, 'corp-') THEN
             splitByChar('/', meta_client_name)[3]
         ELSE
             splitByChar('/', meta_client_name)[-1]
@@ -31,6 +35,8 @@ SELECT
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
             'individual'
+        WHEN startsWith(meta_client_name, 'corp-') THEN
+            'corporate'
         WHEN startsWith(meta_client_name, 'ethpandaops') THEN
             'internal'
         ELSE

--- a/models/transformations/int_attestation_first_seen.sql
+++ b/models/transformations/int_attestation_first_seen.sql
@@ -96,11 +96,15 @@ SELECT
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
             splitByChar('/', meta_client_name)[2]
+        WHEN startsWith(meta_client_name, 'corp-') THEN
+            splitByChar('/', meta_client_name)[2]
         ELSE
             'ethpandaops'
     END AS username,
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
+            splitByChar('/', meta_client_name)[3]
+        WHEN startsWith(meta_client_name, 'corp-') THEN
             splitByChar('/', meta_client_name)[3]
         ELSE
             splitByChar('/', meta_client_name)[-1]
@@ -108,6 +112,8 @@ SELECT
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
             'individual'
+        WHEN startsWith(meta_client_name, 'corp-') THEN
+            'corporate'
         WHEN startsWith(meta_client_name, 'ethpandaops') THEN
             'internal'
         ELSE

--- a/pkg/proto/clickhouse/fct_attestation_correctness_by_validator_canonical.pb.go
+++ b/pkg/proto/clickhouse/fct_attestation_correctness_by_validator_canonical.pb.go
@@ -44,7 +44,7 @@ type FctAttestationCorrectnessByValidatorCanonical struct {
 	SlotDistance *wrapperspb.UInt32Value `protobuf:"bytes,18,opt,name=slot_distance,json=slotDistance,proto3" json:"slot_distance,omitempty"`
 	// The distance from the slot when the attestation was included in a block
 	InclusionDistance *wrapperspb.UInt32Value `protobuf:"bytes,19,opt,name=inclusion_distance,json=inclusionDistance,proto3" json:"inclusion_distance,omitempty"`
-	// Can be "canonical", "orphaned" or "missed"
+	// Can be "canonical", "orphaned", "missed" or "unknown" (validator attested but block data not available)
 	Status string `protobuf:"bytes,20,opt,name=status,proto3" json:"status,omitempty"`
 }
 

--- a/pkg/proto/clickhouse/fct_attestation_correctness_by_validator_canonical.proto
+++ b/pkg/proto/clickhouse/fct_attestation_correctness_by_validator_canonical.proto
@@ -27,7 +27,7 @@ message FctAttestationCorrectnessByValidatorCanonical {
   google.protobuf.UInt32Value slot_distance = 18;
   // The distance from the slot when the attestation was included in a block
   google.protobuf.UInt32Value inclusion_distance = 19;
-  // Can be "canonical", "orphaned" or "missed"
+  // Can be "canonical", "orphaned", "missed" or "unknown" (validator attested but block data not available)
   string status = 20;
 }
 

--- a/pkg/proto/clickhouse/fct_block_blob_first_seen_by_node.pb.go
+++ b/pkg/proto/clickhouse/fct_block_blob_first_seen_by_node.pb.go
@@ -48,7 +48,7 @@ type FctBlockBlobFirstSeenByNode struct {
 	Username string `protobuf:"bytes,20,opt,name=username,proto3" json:"username,omitempty"`
 	// ID of the node
 	NodeId string `protobuf:"bytes,21,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
-	// Classification of the node, e.g. "individual", "institution", "internal" (aka ethPandaOps) or "unclassified"
+	// Classification of the node, e.g. "individual", "corporate", "internal" (aka ethPandaOps) or "unclassified"
 	Classification string `protobuf:"bytes,22,opt,name=classification,proto3" json:"classification,omitempty"`
 	// Name of the client
 	MetaClientName string `protobuf:"bytes,23,opt,name=meta_client_name,json=metaClientName,proto3" json:"meta_client_name,omitempty"`

--- a/pkg/proto/clickhouse/fct_block_blob_first_seen_by_node.proto
+++ b/pkg/proto/clickhouse/fct_block_blob_first_seen_by_node.proto
@@ -31,7 +31,7 @@ message FctBlockBlobFirstSeenByNode {
   string username = 20;
   // ID of the node
   string node_id = 21;
-  // Classification of the node, e.g. "individual", "institution", "internal" (aka ethPandaOps) or "unclassified"
+  // Classification of the node, e.g. "individual", "corporate", "internal" (aka ethPandaOps) or "unclassified"
   string classification = 22;
   // Name of the client
   string meta_client_name = 23;

--- a/pkg/proto/clickhouse/fct_block_first_seen_by_node.pb.go
+++ b/pkg/proto/clickhouse/fct_block_first_seen_by_node.pb.go
@@ -46,7 +46,7 @@ type FctBlockFirstSeenByNode struct {
 	Username string `protobuf:"bytes,19,opt,name=username,proto3" json:"username,omitempty"`
 	// ID of the node
 	NodeId string `protobuf:"bytes,20,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
-	// Classification of the node, e.g. "individual", "institution", "internal" (aka ethPandaOps) or "unclassified"
+	// Classification of the node, e.g. "individual", "corporate", "internal" (aka ethPandaOps) or "unclassified"
 	Classification string `protobuf:"bytes,21,opt,name=classification,proto3" json:"classification,omitempty"`
 	// Name of the client
 	MetaClientName string `protobuf:"bytes,22,opt,name=meta_client_name,json=metaClientName,proto3" json:"meta_client_name,omitempty"`

--- a/pkg/proto/clickhouse/fct_block_first_seen_by_node.proto
+++ b/pkg/proto/clickhouse/fct_block_first_seen_by_node.proto
@@ -29,7 +29,7 @@ message FctBlockFirstSeenByNode {
   string username = 19;
   // ID of the node
   string node_id = 20;
-  // Classification of the node, e.g. "individual", "institution", "internal" (aka ethPandaOps) or "unclassified"
+  // Classification of the node, e.g. "individual", "corporate", "internal" (aka ethPandaOps) or "unclassified"
   string classification = 21;
   // Name of the client
   string meta_client_name = 22;

--- a/pkg/proto/clickhouse/fct_node_active_last_24h.pb.go
+++ b/pkg/proto/clickhouse/fct_node_active_last_24h.pb.go
@@ -34,7 +34,7 @@ type FctNodeActiveLast24H struct {
 	Username string `protobuf:"bytes,13,opt,name=username,proto3" json:"username,omitempty"`
 	// ID of the node
 	NodeId string `protobuf:"bytes,14,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
-	// Classification of the node, e.g. "individual", "institution", "internal" (aka ethPandaOps) or "unclassified"
+	// Classification of the node, e.g. "individual", "corporate", "internal" (aka ethPandaOps) or "unclassified"
 	Classification string `protobuf:"bytes,15,opt,name=classification,proto3" json:"classification,omitempty"`
 	// Name of the client
 	MetaClientName string `protobuf:"bytes,16,opt,name=meta_client_name,json=metaClientName,proto3" json:"meta_client_name,omitempty"`

--- a/pkg/proto/clickhouse/fct_node_active_last_24h.proto
+++ b/pkg/proto/clickhouse/fct_node_active_last_24h.proto
@@ -17,7 +17,7 @@ message FctNodeActiveLast24h {
   string username = 13;
   // ID of the node
   string node_id = 14;
-  // Classification of the node, e.g. "individual", "institution", "internal" (aka ethPandaOps) or "unclassified"
+  // Classification of the node, e.g. "individual", "corporate", "internal" (aka ethPandaOps) or "unclassified"
   string classification = 15;
   // Name of the client
   string meta_client_name = 16;

--- a/pkg/proto/clickhouse/int_attestation_first_seen.pb.go
+++ b/pkg/proto/clickhouse/int_attestation_first_seen.pb.go
@@ -50,7 +50,7 @@ type IntAttestationFirstSeen struct {
 	Username string `protobuf:"bytes,21,opt,name=username,proto3" json:"username,omitempty"`
 	// ID of the node
 	NodeId string `protobuf:"bytes,22,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
-	// Classification of the node, e.g. "individual", "institution", "internal" (aka ethPandaOps) or "unclassified"
+	// Classification of the node, e.g. "individual", "corporate", "internal" (aka ethPandaOps) or "unclassified"
 	Classification string `protobuf:"bytes,23,opt,name=classification,proto3" json:"classification,omitempty"`
 	// Name of the client
 	MetaClientName string `protobuf:"bytes,24,opt,name=meta_client_name,json=metaClientName,proto3" json:"meta_client_name,omitempty"`

--- a/pkg/proto/clickhouse/int_attestation_first_seen.proto
+++ b/pkg/proto/clickhouse/int_attestation_first_seen.proto
@@ -33,7 +33,7 @@ message IntAttestationFirstSeen {
   string username = 21;
   // ID of the node
   string node_id = 22;
-  // Classification of the node, e.g. "individual", "institution", "internal" (aka ethPandaOps) or "unclassified"
+  // Classification of the node, e.g. "individual", "corporate", "internal" (aka ethPandaOps) or "unclassified"
   string classification = 23;
   // Name of the client
   string meta_client_name = 24;


### PR DESCRIPTION
Add support for 'corp-' prefixed nodes across all transformation models and migrations. This enables classification of corporate nodes alongside existing individual and internal categories.