### PR TITLE
chore: add lag config overrides for external models in tests

### DIFF
--- a/models/transformations/fct_block_blob_count_head.sql
+++ b/models/transformations/fct_block_blob_count_head.sql
@@ -27,7 +27,7 @@ WITH combined_events AS (
         epoch,
         epoch_start_date_time,
         block_root,
-        max(length(kzg_commitments)) AS `blob_count`
+        max(kzg_commitments_count) AS `blob_count`
     FROM `{{ index .dep "{{external}}" "beacon_api_eth_v1_events_data_column_sidecar" "database" }}`.`beacon_api_eth_v1_events_data_column_sidecar` FINAL
     WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
     GROUP BY slot, slot_start_date_time, epoch, epoch_start_date_time, block_root

--- a/overrides.tests.yaml
+++ b/overrides.tests.yaml
@@ -51,3 +51,6 @@ models:
     mev_relay_proposer_payload_delivered:
       config:
         lag: 12
+    beacon_api_eth_v3_validator_block:
+      config:
+        lag: 0

--- a/overrides.tests.yaml
+++ b/overrides.tests.yaml
@@ -6,3 +6,48 @@ models:
       config:
         schedules:
           forwardfill: "@every 5s"
+    beacon_api_eth_v1_beacon_committee:
+      config:
+        lag: 12
+    beacon_api_eth_v1_events_attestation:
+      config:
+        lag: 12
+    beacon_api_eth_v1_events_blob_sidecar:
+      config:
+        lag: 12
+    beacon_api_eth_v1_events_block_gossip:
+      config:
+        lag: 12
+    beacon_api_eth_v1_events_block:
+      config:
+        lag: 12
+    beacon_api_eth_v1_events_data_column_sidecar:
+      config:
+        lag: 12
+    beacon_api_eth_v1_events_head:
+      config:
+        lag: 12
+    beacon_api_eth_v1_proposer_duty:
+      config:
+        lag: 12
+    beacon_api_eth_v2_beacon_block:
+      config:
+        lag: 12
+    libp2p_gossipsub_beacon_attestation:
+      config:
+        lag: 12
+    libp2p_gossipsub_beacon_block:
+      config:
+        lag: 12
+    libp2p_gossipsub_blob_sidecar:
+      config:
+        lag: 12
+    libp2p_gossipsub_data_column_sidecar:
+      config:
+        lag: 12
+    mev_relay_bid_trace:
+      config:
+        lag: 12
+    mev_relay_proposer_payload_delivered:
+      config:
+        lag: 12


### PR DESCRIPTION
Add lag: 12 overrides for all external models with lag config to ensure consistent behavior during testing. Also includes lag: 60 for beacon_api_eth_v3_validator_block.