### PR TITLE
fix(int_attestation_first_seen_aggregate): drop beacon_api source (EIP-7549 multi-committee bug)

### DIFF
--- a/models/transformations/int_attestation_first_seen_aggregate.sql
+++ b/models/transformations/int_attestation_first_seen_aggregate.sql
@@ -12,7 +12,6 @@ tags:
   - attestation
   - aggregate
 dependencies:
-  - "{{external}}.beacon_api_eth_v1_events_attestation"
   - "{{external}}.libp2p_gossipsub_aggregate_and_proof"
   - "{{external}}.canonical_beacon_committee"
 ---
@@ -20,6 +19,9 @@ INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`
 -- Dedup aggregates by (slot, committee_index, aggregation_bits) first. Many sentries see
 -- the same aggregate — decoding every copy would be 50-100x slower.
+-- Source is libp2p_gossipsub_aggregate_and_proof only. The beacon_api aggregate stream
+-- mixes per-committee aggregates with EIP-7549 (post-Electra) multi-committee aggregates
+-- whose bit layout cannot be decoded without committee_bits, which xatu does not expose.
 WITH aggregates AS (
     SELECT
         slot,
@@ -29,34 +31,14 @@ WITH aggregates AS (
         committee_index,
         aggregation_bits,
         MIN(propagation_slot_start_diff) AS agg_seen,
-        argMin(source, propagation_slot_start_diff) AS source,
         argMin(beacon_block_root, propagation_slot_start_diff) AS beacon_block_root,
         argMin(source_epoch, propagation_slot_start_diff) AS source_epoch,
         argMin(source_root, propagation_slot_start_diff) AS source_root,
         argMin(target_epoch, propagation_slot_start_diff) AS target_epoch,
         argMin(target_root, propagation_slot_start_diff) AS target_root
-    FROM (
-        SELECT
-            'beacon_api_eth_v1_events_attestation' AS source,
-            slot, slot_start_date_time, epoch, epoch_start_date_time,
-            committee_index, aggregation_bits, propagation_slot_start_diff,
-            beacon_block_root, source_epoch, source_root, target_epoch, target_root
-        FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_events_attestation" "helpers" "from" }}
-        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
-            AND meta_network_name = '{{ .env.NETWORK }}'
-            AND aggregation_bits != ''
-
-        UNION ALL
-
-        SELECT
-            'libp2p_gossipsub_aggregate_and_proof' AS source,
-            slot, slot_start_date_time, epoch, epoch_start_date_time,
-            committee_index, aggregation_bits, propagation_slot_start_diff,
-            beacon_block_root, source_epoch, source_root, target_epoch, target_root
-        FROM {{ index .dep "{{external}}" "libp2p_gossipsub_aggregate_and_proof" "helpers" "from" }} FINAL
-        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
-            AND meta_network_name = '{{ .env.NETWORK }}'
-    )
+    FROM {{ index .dep "{{external}}" "libp2p_gossipsub_aggregate_and_proof" "helpers" "from" }} FINAL
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+        AND meta_network_name = '{{ .env.NETWORK }}'
     GROUP BY slot, slot_start_date_time, epoch, epoch_start_date_time,
              committee_index, aggregation_bits
 ),
@@ -85,7 +67,6 @@ exploded AS (
         a.committee_index,
         c.validators[p + 1] AS attesting_validator_index,
         a.agg_seen,
-        a.source,
         a.beacon_block_root,
         a.source_epoch,
         a.source_root,
@@ -117,7 +98,7 @@ SELECT
     target_epoch,
     target_root,
     MIN(agg_seen) AS seen_slot_start_diff,
-    argMin(source, agg_seen) AS source
+    'libp2p_gossipsub_aggregate_and_proof' AS source
 FROM exploded
 GROUP BY slot_start_date_time, attesting_validator_index,
          beacon_block_root, source_epoch, source_root, target_epoch, target_root

--- a/tests/mainnet/models/fct_attestation_first_seen_by_validator.yaml
+++ b/tests/mainnet/models/fct_attestation_first_seen_by_validator.yaml
@@ -51,10 +51,10 @@ assertions:
         - type: equals
           column: invalid_raw_source
           value: 0
-    - name: Agg source must be valid or empty when no aggregate observation
+    - name: Agg source must be libp2p_gossipsub_aggregate_and_proof or empty
       sql: |
         SELECT COUNT(*) AS invalid_agg_source FROM fct_attestation_first_seen_by_validator FINAL
-        WHERE agg_source NOT IN ('beacon_api_eth_v1_events_attestation', 'libp2p_gossipsub_aggregate_and_proof', '')
+        WHERE agg_source NOT IN ('libp2p_gossipsub_aggregate_and_proof', '')
       assertions:
         - type: equals
           column: invalid_agg_source
@@ -106,4 +106,16 @@ assertions:
       assertions:
         - type: equals
           column: dupes
+          value: 0
+    - name: A validator should not appear with >1 distinct vote per slot (catches misdecoded multi-committee aggregates)
+      sql: |
+        SELECT COUNT(*) AS slashable_pairs FROM (
+          SELECT slot, validator_index
+          FROM fct_attestation_first_seen_by_validator FINAL
+          GROUP BY slot, validator_index
+          HAVING count(DISTINCT (block_root, source_epoch, source_root, target_epoch, target_root)) > 1
+        )
+      assertions:
+        - type: equals
+          column: slashable_pairs
           value: 0

--- a/tests/mainnet/models/int_attestation_first_seen_aggregate.yaml
+++ b/tests/mainnet/models/int_attestation_first_seen_aggregate.yaml
@@ -1,9 +1,6 @@
 model: int_attestation_first_seen_aggregate
 network: mainnet
 external_data:
-    beacon_api_eth_v1_events_attestation:
-        url: https://data.ethpandaops.io/xatu-cbt/mainnet/fusaka/int_attestation_first_seen_aggregate_beacon_api_eth_v1_events_attestation.parquet
-        network_column: meta_network_name
     libp2p_gossipsub_aggregate_and_proof:
         url: https://data.ethpandaops.io/xatu-cbt/mainnet/fusaka/int_attestation_first_seen_aggregate_libp2p_gossipsub_aggregate_and_proof.parquet
         network_column: meta_network_name
@@ -39,9 +36,9 @@ assertions:
         - type: equals
           column: negative_validators
           value: 0
-    - name: Source should only contain valid values
+    - name: Source should only contain libp2p_gossipsub_aggregate_and_proof
       sql: |
-        SELECT COUNT(*) AS invalid_source_count FROM int_attestation_first_seen_aggregate FINAL WHERE source NOT IN ('beacon_api_eth_v1_events_attestation', 'libp2p_gossipsub_aggregate_and_proof')
+        SELECT COUNT(*) AS invalid_source_count FROM int_attestation_first_seen_aggregate FINAL WHERE source != 'libp2p_gossipsub_aggregate_and_proof'
       assertions:
         - type: equals
           column: invalid_source_count


### PR DESCRIPTION
## Summary

`int_attestation_first_seen_aggregate` was decoding `aggregation_bits` from
`beacon_api_eth_v1_events_attestation` against a single committee's roster.
Post-Electra (EIP-7549), beacon_api's aggregate stream contains both per-committee
aggregates AND raw multi-committee aggregates whose bits span up to 64 committees.
The decode silently ran the multi-committee bits against one committee, emitting
wrong validators for wrong votes.

In production over 200 slots this produced **5,294 false slashable-double-vote
rows** — validators appearing with two distinct votes in a single slot when they
had only signed one.

## Why this scope

xatu does not expose `committee_bits`, so the multi-committee bits cannot be
decoded correctly without a xatu schema change. `libp2p_gossipsub_aggregate_and_proof`
emits only per-committee aggregates so we rely on it as the sole agg source.
`canonical_beacon_elaborated_attestation` has pre-decoded validators but only
covers block-included attestations.

## What changed

- `int_attestation_first_seen_aggregate.sql`: agg source = libp2p only
- Test YAMLs: drop the beacon_api parquet seed; tighten the source-enum assertions
- Add a fct assertion that fails if any `(slot, validator_index)` has >1 distinct
  vote — catches multi-committee decode bugs going forward

## Production impact

Production tables are populated with corrupted data and need to be wiped + backfilled
after this merges. Local test passes 21/21 (was 20/20 + new slashable assertion).