### PR TITLE
Optimize 1m storage slot expiry lookup

### DIFF
--- a/models/transformations/int_storage_slot_expiry_1m.sql
+++ b/models/transformations/int_storage_slot_expiry_1m.sql
@@ -15,7 +15,9 @@ tags:
   - expiry
   - 1m
 dependencies:
+  - "{{external}}.canonical_execution_storage_reads"
   - "{{transformation}}.int_storage_slot_diff_by_address_slot"
+  - "{{transformation}}.int_storage_slot_diff"
   - "{{transformation}}.int_storage_slot_next_touch"
   - "{{transformation}}.int_execution_block_by_date"
   - "{{external}}.canonical_execution_block"
@@ -65,11 +67,6 @@ old_touches_with_next AS (
     WHERE block_number BETWEEN (SELECT min_old_block FROM old_block_range) AND (SELECT max_old_block FROM old_block_range)
     GROUP BY block_number, address, slot_key
 ),
--- Unique address/slot pairs for efficient lookups
-unique_pairs AS (
-    SELECT DISTINCT address, slot_key
-    FROM old_touches_with_next
-),
 -- Block metadata for old window
 -- Use GROUP BY with argMax to properly deduplicate across shards when using cluster()
 -- FINAL only deduplicates locally within each shard, not across the distributed result
@@ -94,35 +91,56 @@ touches_with_metadata AS (
     INNER JOIN old_block_metadata bm
         ON t.block_number = bm.block_number
 ),
--- Lookup effective_bytes at the time of each touch from historical diffs
--- Uses int_storage_slot_diff_by_address_slot which is ordered by (address, slot_key, block_number)
--- for efficient filtering and argMax aggregation
-latest_diffs_for_candidates AS (
+-- Compute effective_bytes from the touch event itself:
+-- writes use end-of-block effective_bytes_to, reads use the value read.
+touch_value_events AS (
     SELECT
+        block_number,
         address,
         slot_key,
-        argMax(block_number, block_number) as diff_block,
-        argMax(effective_bytes_to, block_number) as effective_bytes
-    FROM {{ index .dep "{{transformation}}" "int_storage_slot_diff_by_address_slot" "helpers" "from" }}
-    WHERE block_number <= (SELECT max_old_block FROM old_block_range)
-        AND (address, slot_key) IN (SELECT address, slot_key FROM unique_pairs)
-    GROUP BY address, slot_key
+        2 as priority,
+        argMax(effective_bytes_to, updated_date_time) as effective_bytes
+    FROM {{ index .dep "{{transformation}}" "int_storage_slot_diff" "helpers" "from" }}
+    WHERE block_number BETWEEN (SELECT min_old_block FROM old_block_range) AND (SELECT max_old_block FROM old_block_range)
+    GROUP BY block_number, address, slot_key
+
+    UNION ALL
+
+    SELECT
+        block_number,
+        contract_address as address,
+        slot as slot_key,
+        1 as priority,
+        toUInt8((length(trimLeft(substring(argMax(value, (transaction_index, internal_index)), 3), '0')) + 1) / 2) as effective_bytes
+    FROM {{ index .dep "{{external}}" "canonical_execution_storage_reads" "helpers" "from" }}
+    WHERE block_number BETWEEN (SELECT min_old_block FROM old_block_range) AND (SELECT max_old_block FROM old_block_range)
+        AND meta_network_name = '{{ .env.NETWORK }}'
+    GROUP BY block_number, address, slot_key
 ),
--- Candidate expiries: touches with valid effective_bytes at touch time
-candidate_expiries AS (
+touch_effective_bytes AS (
+    SELECT
+        block_number,
+        address,
+        slot_key,
+        argMax(effective_bytes, priority) as effective_bytes
+    FROM touch_value_events
+    GROUP BY block_number, address, slot_key
+),
+-- Candidate expiries from touch values before enforcing original historical-diff semantics.
+pre_candidate_expiries AS (
     SELECT
         t.touch_block,
         t.touch_time,
         t.address,
         t.slot_key,
         t.next_touch_block,
-        d.effective_bytes as effective_bytes
+        e.effective_bytes as effective_bytes
     FROM touches_with_metadata t
-    LEFT JOIN latest_diffs_for_candidates d
-        ON t.address = d.address
-        AND t.slot_key = d.slot_key
-    WHERE d.diff_block <= t.touch_block
-        AND d.effective_bytes > 0
+    INNER JOIN touch_effective_bytes e
+        ON t.touch_block = e.block_number
+        AND t.address = e.address
+        AND t.slot_key = e.slot_key
+    WHERE e.effective_bytes > 0
 ),
 -- Map touch_time to the GLOBAL first block where it becomes 1 month old
 -- Only include if that block falls within current bounds (deterministic per touch)
@@ -130,24 +148,56 @@ first_expiry_block_map AS (
     SELECT
         c.touch_time,
         min(b.block_number) as first_expiry_block
-    FROM (SELECT DISTINCT touch_time FROM candidate_expiries) c
+    FROM (SELECT DISTINCT touch_time FROM pre_candidate_expiries) c
     INNER JOIN expiry_block_candidates b
         ON b.block_date_time >= c.touch_time + INTERVAL 1 MONTH
     GROUP BY c.touch_time
     HAVING first_expiry_block BETWEEN {{ .bounds.start }} AND {{ .bounds.end }}
+),
+candidate_rows AS (
+    SELECT
+        fromUnixTimestamp({{ .task.start }}) as updated_date_time,
+        f.first_expiry_block as block_number,
+        c.address,
+        c.slot_key,
+        c.touch_block,
+        c.effective_bytes
+    FROM pre_candidate_expiries c
+    INNER JOIN first_expiry_block_map f ON c.touch_time = f.touch_time
+    WHERE
+        -- No touch between original touch and expiry
+        (c.next_touch_block IS NULL OR c.next_touch_block > f.first_expiry_block)
+),
+candidate_pairs AS (
+    SELECT DISTINCT address, slot_key
+    FROM candidate_rows
+),
+-- Preserve the original historical-diff semantics, but only for rows that survived
+-- the cheaper touch-value and expiry-block filters.
+latest_diffs_for_candidate_rows AS (
+    SELECT
+        address,
+        slot_key,
+        argMax(block_number, block_number) as diff_block,
+        argMax(effective_bytes_to, block_number) as effective_bytes
+    FROM {{ index .dep "{{transformation}}" "int_storage_slot_diff_by_address_slot" "helpers" "from" }}
+    WHERE block_number <= (SELECT max_old_block FROM old_block_range)
+        AND (address, slot_key) IN (SELECT address, slot_key FROM candidate_pairs)
+    GROUP BY address, slot_key
 )
 SELECT
-    fromUnixTimestamp({{ .task.start }}) as updated_date_time,
-    f.first_expiry_block as block_number,
+    c.updated_date_time,
+    c.block_number,
     c.address,
     c.slot_key,
     c.touch_block,  -- CRITICAL: propagates through waterfall chain for matching reactivations
-    c.effective_bytes
-FROM candidate_expiries c
-INNER JOIN first_expiry_block_map f ON c.touch_time = f.touch_time
-WHERE
-    -- No touch between original touch and expiry
-    (c.next_touch_block IS NULL OR c.next_touch_block > f.first_expiry_block)
+    d.effective_bytes
+FROM candidate_rows c
+INNER JOIN latest_diffs_for_candidate_rows d
+    ON c.address = d.address
+    AND c.slot_key = d.slot_key
+WHERE d.diff_block <= c.touch_block
+    AND d.effective_bytes > 0
 SETTINGS
     max_bytes_before_external_group_by = 10000000000,
     max_bytes_before_external_sort = 10000000000,


### PR DESCRIPTION
## Summary

Optimizes `int_storage_slot_expiry_1m` by narrowing the expensive historical storage-diff lookup to address/slot pairs that survive cheaper expiry candidate filters first.

The previous query collected every touched address/slot pair from the padded one-month-old window, then queried `int_storage_slot_diff_by_address_slot` for all of those pairs. On late mainnet ranges that made the historical lookup dominate runtime and scan volume.

This PR keeps the original padded `old_block_range` semantics intact, then adds a safe prefilter path:

1. Read the existing next-touch rows for the padded old window.
2. Join block metadata to recover each touch timestamp.
3. Compute touch-local `effective_bytes` from writes and reads:
   - writes from `int_storage_slot_diff`
   - reads from `canonical_execution_storage_reads`
   - writes win over reads for the same block/address/slot via priority
4. Build positive-byte pre-candidates and map them to the first in-range expiry block.
5. Apply the `next_touch_block` expiry guard.
6. Only then run the original historical `int_storage_slot_diff_by_address_slot` lookup for the surviving candidate pairs.
7. Keep the final historical `diff_block <= touch_block` and `effective_bytes > 0` checks before output.

## Why This Is Safe

The rewrite does not use the rejected exact one-month old window optimization. It deliberately keeps the original padded month window:

```sql
block_date_time >= min_time - INTERVAL 1 MONTH - INTERVAL 1 DAY
block_date_time <= max_time - INTERVAL 1 MONTH + INTERVAL 1 DAY
```

That matters because calendar-month arithmetic is not invertible around month boundaries. Earlier testing showed exact old-window narrowing can miss valid rows, so this implementation only changes the candidate filtering order, not the time-window semantics.

The final output still comes from the historical diff state check, preserving the original model semantics for effective bytes at touch time.

## Performance Evidence

The safe rewrite was benchmarked with query cache disabled. Filesystem/page cache may still affect absolute wall time.

### 1k late mainnet range: `20492233..20493233`

| Metric | Baseline | Safe rewrite | Change |
| --- | ---: | ---: | ---: |
| Wall time | `658.35s` | `384.09s` | `1.71x faster`, `41.7%` less |
| Query duration | `657.37s` | `383.54s` | `1.71x faster` |
| Read rows | `11.18B` | `1.23B` | `9.1x` fewer |
| Read bytes | `1.32 TiB` | `156.6 GiB` | `8.6x` fewer |
| Peak memory | `1.07 GiB` | `9.87 GiB` | higher |

### 10k late mainnet range: `20482233..20492233`

Safe rewrite only:

| Metric | Safe rewrite |
| --- | ---: |
| Wall time | `645.23s` |
| Query duration | `645.97s` |
| Result rows | `712,556` |
| Read rows | `3.43B` |
| Read bytes | `426.76 GiB` |
| Peak memory | `10.20 GiB` |

Compared with extrapolating the nearby 1k run, a single 10k safe query had much better throughput, but memory remains around `10 GiB` for late ranges.

## Correctness Evidence

Exact hash checks were run with ClickHouse `25.6.13.41`, which does not support `FORMAT Hash`, so validation used the RowBinary SHA-256 fallback with `ORDER BY tuple(*)`.

Safe padded rewrite hash-matched baseline on these 1k windows:

| Range | Rows | SHA-256 |
| --- | ---: | --- |
| `6423187..6424187` | `86,834` | `c1972bbc01010774395cdafc7f57d0e39760d596f7741a5b7089f5430792cb4f` |
| `6752542..6753542` | `58,355` | `cb304c66b9e9ee15b78db35eafdcc722238bcb30488f2ffc85d577dcf0bb17ea` |
| `12353042..12354042` | `63,706` | `447182fc3f830bbe8d93e0d24b290e55a0c8f2376960ced60b2b743416088612` |
| `15878565..15879565` | `174,260` | `17d7dd41380f5769492cc964b56e635370591ae2cbade521d0318fd56052a700` |
| `20492233..20493233` | `67,302` | `a2ababad4f2ed5017970075791a7fd66c7b82d6b2ae5fcf431b7a54d8b2be1b3` |

## Implementation Notes

- Adds explicit dependencies for:
  - `{{external}}.canonical_execution_storage_reads`
  - `{{transformation}}.int_storage_slot_diff`
- Keeps `int_storage_slot_next_touch` as the source of touch existence and `next_touch_block` behavior.
- Uses `argMax(effective_bytes_to, updated_date_time)` for write touch values to preserve ReplacingMergeTree-style dedup behavior.
- Uses read value effective-byte calculation consistent with existing storage models.
- Leaves the existing output shape unchanged.

## Validation

- Rendered the edited model for `20492233..20493233` with `unresolved_count = 0`.
- Compared the rendered query body against the previously hash-checked safe candidate; only intentional differences were removal of an unused `previous_bound` CTE and a clarifying comment.
- Ran `EXPLAIN SYNTAX` against ClickHouse on the rendered SELECT body successfully.
- Ran `git diff --check` successfully.

## Caveats

The rewrite materially reduces scan volume and wall time, but peak memory can be much higher than baseline in late ranges. Observed safe-rewrite peaks were around `9.9-10.2 GiB` on the late mainnet samples above.
