### PR TITLE
fix(models): constrain meta_network_name so scans satisfy force_primary_key

### DIFF
--- a/models/transformations/fct_execution_state_size_daily.sql
+++ b/models/transformations/fct_execution_state_size_daily.sql
@@ -87,6 +87,8 @@ FROM (
             b.block_date_time
         FROM {{ index .dep "{{external}}" "execution_state_size" "helpers" "from" }} AS s FINAL
         GLOBAL INNER JOIN blocks_in_days AS b ON s.block_number = b.block_number
+        WHERE s.meta_network_name = '{{ .env.NETWORK }}'
+          AND s.block_number BETWEEN (SELECT min(block_number) FROM blocks_in_days) AND (SELECT max(block_number) FROM blocks_in_days)
     )
     GROUP BY day_start_date
 )

--- a/models/transformations/fct_execution_state_size_hourly.sql
+++ b/models/transformations/fct_execution_state_size_hourly.sql
@@ -87,6 +87,8 @@ FROM (
             b.block_date_time
         FROM {{ index .dep "{{external}}" "execution_state_size" "helpers" "from" }} AS s FINAL
         GLOBAL INNER JOIN blocks_in_hours AS b ON s.block_number = b.block_number
+        WHERE s.meta_network_name = '{{ .env.NETWORK }}'
+          AND s.block_number BETWEEN (SELECT min(block_number) FROM blocks_in_hours) AND (SELECT max(block_number) FROM blocks_in_hours)
     )
     GROUP BY hour_start_date_time
 )

--- a/models/transformations/fct_node_cpu_utilization_by_process.sql
+++ b/models/transformations/fct_node_cpu_utilization_by_process.sql
@@ -35,3 +35,4 @@ SELECT
     END AS node_class
 FROM {{ index .dep "observoor" "cpu_utilization" "helpers" "from" }} FINAL
 WHERE wallclock_slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+    AND meta_network_name = '{{ .env.NETWORK }}'

--- a/models/transformations/fct_node_disk_io_by_process.sql
+++ b/models/transformations/fct_node_disk_io_by_process.sql
@@ -34,6 +34,7 @@ SELECT
     END AS node_class
 FROM {{ index .dep "observoor" "disk_bytes" "helpers" "from" }} FINAL
 WHERE wallclock_slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+    AND meta_network_name = '{{ .env.NETWORK }}'
 GROUP BY
     window_start,
     wallclock_slot,

--- a/models/transformations/fct_node_memory_usage_by_process.sql
+++ b/models/transformations/fct_node_memory_usage_by_process.sql
@@ -35,3 +35,4 @@ SELECT
     END AS node_class
 FROM {{ index .dep "observoor" "memory_usage" "helpers" "from" }} FINAL
 WHERE wallclock_slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+    AND meta_network_name = '{{ .env.NETWORK }}'

--- a/models/transformations/fct_node_network_io_by_process.sql
+++ b/models/transformations/fct_node_network_io_by_process.sql
@@ -35,3 +35,4 @@ SELECT
     END AS node_class
 FROM {{ index .dep "observoor" "net_io" "helpers" "from" }} FINAL
 WHERE wallclock_slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+    AND meta_network_name = '{{ .env.NETWORK }}'


### PR DESCRIPTION
## Summary

Six transformation models were erroring in production (`mainnet-cbt-646`) with ClickHouse **Code: 277 `INDEX_NOT_USED`** — their source-table scans constrained no primary-key-prefix column while the cluster has `force_primary_key` enabled (intentional).

All raw xatu/observoor source tables have a primary key that **leads with `meta_network_name`**, so a scan must constrain `meta_network_name` for the primary key to be considered "used". Every other (working) transformation model already does this — these six did not. They predate the cluster turning `force_primary_key` on, which is why they worked until recently.

## Erroring models (observed via `stern mainnet-cbt-646 -nclickhouse`)

| Model | Source PK (leads with) | Problem |
|---|---|---|
| `fct_node_network_io_by_process` | `(meta_network_name, window_start, …)` | only filtered `wallclock_slot_start_date_time` (not a key column); no `meta_network_name` |
| `fct_node_cpu_utilization_by_process` | `(meta_network_name, window_start, …)` | same |
| `fct_node_memory_usage_by_process` | `(meta_network_name, window_start, …)` | same |
| `fct_node_disk_io_by_process` | `(meta_network_name, window_start, …)` | same |
| `fct_execution_state_size_daily` | `execution_state_size (meta_network_name, block_number, …)` | `s` scan relied solely on the `GLOBAL INNER JOIN` key |
| `fct_execution_state_size_hourly` | `execution_state_size (meta_network_name, block_number, …)` | same |

## Changes

**Observoor process models** — added the leading-PK predicate to the WHERE:

```sql
AND meta_network_name = '{{ .env.NETWORK }}'
```

**Execution state size models** — added a predicate directly on the `execution_state_size` (`s`) scan that PR #185 missed (it only patched the `canonical_execution_block` CTEs):

```sql
WHERE s.meta_network_name = '{{ .env.NETWORK }}'
  AND s.block_number BETWEEN (SELECT min(block_number) FROM blocks_in_…) AND (SELECT max(block_number) FROM blocks_in_…)
```

A `GLOBAL INNER JOIN` key does not push down as a primary-key condition, so the scan had no usable key column. The added `block_number` range is a contiguous **superset** of the join keys (so results are unchanged) and also stops the scan from reading the network's entire `execution_state_size` history on every incremental run. The block-range subquery mirrors the existing `(SELECT min_day FROM day_bounds)` style already in those files.

## Testing

Not yet run — recommend validating against the cluster before merge:

```bash
xatu-cbt test models \
  fct_node_network_io_by_process,fct_node_cpu_utilization_by_process,fct_node_memory_usage_by_process,fct_node_disk_io_by_process,fct_execution_state_size_daily,fct_execution_state_size_hourly \
  --network mainnet
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)