### PR TITLE
fix: use GLOBAL joins for Distributed-table subqueries (Code 288)

### DIFF
--- a/models/scripts/dim_function_signature.py
+++ b/models/scripts/dim_function_signature.py
@@ -98,7 +98,7 @@ def get_new_selectors(ch_url, target_db, target_table, batch_size, block_lookbac
     )
     SELECT DISTINCT cf.function_selector as selector
     FROM `{target_db}`.int_transaction_call_frame cf
-    LEFT JOIN (
+    GLOBAL LEFT JOIN (
         SELECT selector, name, updated_date_time
         FROM `{target_db}`.`{target_table}`
     ) sig ON cf.function_selector = sig.selector

--- a/models/transformations/fct_reorg_hourly.sql
+++ b/models/transformations/fct_reorg_hourly.sql
@@ -88,7 +88,7 @@ WITH
         SELECT DISTINCT
             e.depth AS depth
         FROM `{{ .self.database }}`.`{{ .self.table }}` AS e FINAL
-        INNER JOIN target_hours h
+        GLOBAL INNER JOIN target_hours h
             ON e.hour_start_date_time = h.hour_start_date_time
     ),
     depth_dim AS (
@@ -101,7 +101,7 @@ WITH
             h.hour_start_date_time,
             d.depth
         FROM target_hours h
-        CROSS JOIN depth_dim d
+        GLOBAL CROSS JOIN depth_dim d
     )
 SELECT
     fromUnixTimestamp({{ .task.start }}) AS updated_date_time,
@@ -109,6 +109,6 @@ SELECT
     c.depth,
     toUInt32(coalesce(r.reorg_count, toUInt32(0))) AS reorg_count
 FROM candidate_rows c
-LEFT JOIN reorg_counts r
+GLOBAL LEFT JOIN reorg_counts r
     ON c.hour_start_date_time = r.hour_start_date_time
     AND c.depth = r.depth


### PR DESCRIPTION
## Summary

Two models were erroring in production with ClickHouse **Code 288 `DISTRIBUTED_IN_JOIN_SUBQUERY_DENIED`**:

> Double-distributed IN/JOIN subqueries is denied (`distributed_product_mode = 'deny'`). …use GLOBAL keyword…

When a query reads a `Distributed` table and JOINs against a subquery that also reads a `Distributed` table, the cluster's `distributed_product_mode='deny'` rejects it. The fix is the `GLOBAL` keyword, which evaluates the right-hand subquery once on the initiator and broadcasts it to the shards — the same pattern already used by the state-size models' `GLOBAL INNER JOIN`.

## Changes

### `models/transformations/fct_reorg_hourly.sql`
All three joins have a right-hand side derived from the Distributed `fct_block_proposer` (or the Distributed self table):

| CTE / clause | Before | After |
|---|---|---|
| `existing_depths` | `INNER JOIN target_hours` | `GLOBAL INNER JOIN target_hours` |
| `candidate_rows` | `CROSS JOIN depth_dim` | `GLOBAL CROSS JOIN depth_dim` |
| final `SELECT` | `LEFT JOIN reorg_counts` | `GLOBAL LEFT JOIN reorg_counts` |

### `models/scripts/dim_function_signature.py`
The `get_new_selectors` query LEFT JOINs a subquery over the Distributed `dim_function_signature` table:
- `LEFT JOIN (...)` → `GLOBAL LEFT JOIN (...)`

## Testing

Not run locally — this needs execution against the cluster. Recommend validating before/after merge:

```bash
xatu-cbt test models fct_reorg_hourly,dim_function_signature --network mainnet
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)