### PR TITLE
fix(models): correct multi-shard aggregation bugs + dim_node remote cluster macro

### DIFF
--- a/migrations/007_attestation_first_seen.up.sql
+++ b/migrations/007_attestation_first_seen.up.sql
@@ -40,5 +40,9 @@ CREATE TABLE `${NETWORK_NAME}`.int_attestation_first_seen ON CLUSTER '{cluster}'
     '{cluster}',
     '${NETWORK_NAME}',
     int_attestation_first_seen_local,
-    cityHash64(`slot_start_date_time`, `attesting_validator_index`)
+    -- Sharded by slot only (not attesting_validator_index) so ALL of a slot's first-seen rows
+    -- co-locate on one shard. Downstream models regroup by node/block_root/chunk (grains that
+    -- contain slot_start_date_time but not attesting_validator_index); slot-only sharding keeps
+    -- their shard-local aggregation complete instead of partial-per-shard.
+    cityHash64(`slot_start_date_time`)
 );

--- a/migrations/032_int_execution_block_by_date.up.sql
+++ b/migrations/032_int_execution_block_by_date.up.sql
@@ -1,7 +1,8 @@
 CREATE TABLE `${NETWORK_NAME}`.int_execution_block_by_date_local ON CLUSTER '{cluster}' (
     `updated_date_time` DateTime COMMENT 'Timestamp when the record was last updated' CODEC(DoubleDelta, ZSTD(1)),
     `block_date_time` DateTime64(3) COMMENT 'The block timestamp' CODEC(DoubleDelta, ZSTD(1)),
-    `block_number` UInt64 COMMENT 'The block number' CODEC(DoubleDelta, ZSTD(1))
+    `block_number` UInt64 COMMENT 'The block number' CODEC(DoubleDelta, ZSTD(1)),
+    `transaction_count` UInt32 COMMENT 'Number of transactions in the block' CODEC(ZSTD(1))
 ) ENGINE = ReplicatedReplacingMergeTree(
     '/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}',
     '{replica}',

--- a/migrations/034_int_custody_probe.up.sql
+++ b/migrations/034_int_custody_probe.up.sql
@@ -64,8 +64,12 @@ ENGINE = Distributed(
     '{cluster}',
     '${NETWORK_NAME}',
     int_custody_probe_local,
+    -- Sharded by (slot, peer_id_unique_key), NOT probe_date_time. The downstream
+    -- int_custody_probe_order_by_slot re-keys to (slot_start_date_time, slot, peer_id_unique_key);
+    -- since slot determines slot_start_date_time, this co-locates every re-keyed dedup group on one
+    -- shard so its ReplacingMergeTree FINAL can collapse it (probe_date_time-based sharding scattered
+    -- the same logical row across shards, which FINAL cannot dedup cross-shard).
     cityHash64(
-        probe_date_time,
         slot,
         peer_id_unique_key
     )

--- a/migrations/056_gas_profiling.up.sql
+++ b/migrations/056_gas_profiling.up.sql
@@ -45,7 +45,7 @@ ENGINE = Distributed(
     '{cluster}',
     '${NETWORK_NAME}',
     int_transaction_opcode_gas_local,
-    cityHash64(block_number, transaction_hash)
+    cityHash64(block_number)
 );
 
 -- Projection for opcode-first queries (e.g., "how much gas did SLOAD use across blocks?")
@@ -112,7 +112,7 @@ ENGINE = Distributed(
   '{cluster}',
   '${NETWORK_NAME}',
   int_transaction_call_frame_local,
-  cityHash64(block_number, transaction_hash)
+  cityHash64(block_number)
 );
 
 -- Projection for transaction lookups without block_number
@@ -169,7 +169,7 @@ ENGINE = Distributed(
     '{cluster}',
     '${NETWORK_NAME}',
     int_transaction_call_frame_opcode_gas_local,
-    cityHash64(block_number, transaction_hash)
+    cityHash64(block_number)
 );
 
 -- Projection for frame-first queries (e.g., "what opcodes did frame 15 execute?")

--- a/migrations/058_fct_validator_performance.up.sql
+++ b/migrations/058_fct_validator_performance.up.sql
@@ -435,7 +435,11 @@ CREATE TABLE `${NETWORK_NAME}`.dim_validator_status_local ON CLUSTER '{cluster}'
     '/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}',
     '{replica}',
     `version`
-) PARTITION BY toStartOfMonth(epoch_start_date_time)
+-- No monthly partitioning: ReplacingMergeTree only dedups within a partition, so partitioning by
+-- epoch_start_date_time let a (validator_index, status) whose status window straddled a month
+-- boundary survive as two rows (two different "first epoch" values) that FINAL could never collapse.
+-- tuple() keeps every (validator_index, status) in one partition. This is a small dimension table.
+) PARTITION BY tuple()
 ORDER BY (validator_index, status)
 COMMENT 'Validator lifecycle status transitions — one row per (validator_index, status) with the first epoch observed';
 

--- a/migrations/074_resource_gas.up.sql
+++ b/migrations/074_resource_gas.up.sql
@@ -71,7 +71,7 @@ ENGINE = Distributed(
     '{cluster}',
     '${NETWORK_NAME}',
     int_transaction_call_frame_opcode_resource_gas_local,
-    cityHash64(block_number, transaction_hash)
+    cityHash64(block_number)
 );
 
 -- =============================================================================
@@ -118,7 +118,7 @@ ENGINE = Distributed(
     '{cluster}',
     '${NETWORK_NAME}',
     int_transaction_resource_gas_local,
-    cityHash64(block_number, transaction_hash)
+    cityHash64(block_number)
 );
 
 -- =============================================================================

--- a/migrations/076_receipt_size.up.sql
+++ b/migrations/076_receipt_size.up.sql
@@ -41,7 +41,7 @@ ENGINE = Distributed(
     '{cluster}',
     '${NETWORK_NAME}',
     int_transaction_receipt_size_local,
-    cityHash64(block_number, transaction_hash)
+    cityHash64(block_number)
 );
 
 -- =============================================================================

--- a/models/scripts/dim_node.py
+++ b/models/scripts/dim_node.py
@@ -118,7 +118,7 @@ def fetch_ethseer_validators(ch_url, database_name, external_database):
     SELECT
         `index` AS validator_index,
         entity AS source
-    FROM cluster('{{remote_cluster}}', {db}.ethseer_validator_entity_local)
+    FROM cluster('{{raw}}', {db}.ethseer_validator_entity_local)
     FINAL
     WHERE meta_network_name = '{database_name}'
     FORMAT JSONCompact

--- a/models/transformations/fct_execution_tps_hourly.sql
+++ b/models/transformations/fct_execution_tps_hourly.sql
@@ -15,7 +15,6 @@ tags:
   - tps
   - transactions
 dependencies:
-  - "{{external}}.canonical_execution_transaction"
   - "{{transformation}}.int_execution_block_by_date"
 ---
 -- Hourly aggregation of execution layer TPS (transactions per second).
@@ -42,7 +41,12 @@ WITH
         SELECT
             block_number,
             block_date_time,
-            toUnixTimestamp(block_date_time) AS block_timestamp
+            toUnixTimestamp(block_date_time) AS block_timestamp,
+            -- transaction_count is precomputed in int_execution_block_by_date (a simple top-level
+            -- aggregation that merges across shards). This query therefore does NO transaction
+            -- counting of its own - it is a straight per-block lookup, correct regardless of whether
+            -- the model executes on the coordinator or shard-local.
+            transaction_count
         FROM {{ index .dep "{{transformation}}" "int_execution_block_by_date" "helpers" "from" }} FINAL
         WHERE block_date_time >= (SELECT min_hour FROM hour_bounds)
           AND block_date_time < (SELECT max_hour FROM hour_bounds) + INTERVAL 1 HOUR
@@ -54,37 +58,28 @@ WITH
             block_number,
             block_date_time,
             block_timestamp,
+            transaction_count,
             dateDiff('second',
                 lagInFrame(block_date_time, 1, block_date_time) OVER (ORDER BY block_number),
                 block_date_time
             ) AS block_time_seconds
         FROM blocks_in_hours
     ),
-    -- Count transactions per block from canonical_execution_transaction
-    tx_per_block AS (
-        SELECT
-            block_number,
-            count() AS tx_count
-        FROM {{ index .dep "{{external}}" "canonical_execution_transaction" "helpers" "from" }} FINAL
-        WHERE block_number GLOBAL IN (SELECT block_number FROM blocks_in_hours)
-        GROUP BY block_number
-    ),
-    -- Join blocks with transactions and calculate per-block TPS
+    -- Calculate per-block TPS from the precomputed transaction_count
     blocks_with_tps AS (
         SELECT
-            b.block_number,
-            b.block_date_time,
-            b.block_timestamp,
-            b.block_time_seconds,
-            COALESCE(t.tx_count, 0) AS tx_count,
+            block_number,
+            block_date_time,
+            block_timestamp,
+            block_time_seconds,
+            transaction_count AS tx_count,
             -- TPS = tx_count / actual_time_seconds (avoid div by zero)
-            if(b.block_time_seconds > 0,
-               toFloat32(COALESCE(t.tx_count, 0)) / toFloat32(b.block_time_seconds),
+            if(block_time_seconds > 0,
+               toFloat32(transaction_count) / toFloat32(block_time_seconds),
                0) AS tps
-        FROM blocks_with_time b
-        GLOBAL LEFT JOIN tx_per_block t ON b.block_number = t.block_number
-        WHERE b.block_time_seconds IS NOT NULL  -- Skip first block (no previous to calculate gap)
-          AND b.block_time_seconds > 0          -- Skip zero-time blocks
+        FROM blocks_with_time
+        WHERE block_time_seconds IS NOT NULL  -- Skip first block (no previous to calculate gap)
+          AND block_time_seconds > 0          -- Skip zero-time blocks
     ),
     -- Calculate 5-minute moving average for each block
     blocks_with_ma AS (

--- a/models/transformations/fct_opcode_gas_by_opcode_daily.sql
+++ b/models/transformations/fct_opcode_gas_by_opcode_daily.sql
@@ -51,8 +51,12 @@ SELECT
     sum(o.count) AS total_count,
     sum(o.gas) AS total_gas,
     sum(o.error_count) AS total_error_count,
-    round(avg(o.count), 4) AS avg_count_per_block,
-    round(avg(o.gas), 4) AS avg_gas_per_block,
+    -- Compute per-block averages as total / distinct-blocks rather than avg() over the source rows.
+    -- int_block_opcode_gas can carry multiple partial rows per (block, opcode) across shards, so
+    -- avg(o.gas) would divide by the inflated row count; sum()/count(DISTINCT block_number) is the
+    -- true per-block average regardless of how many partial rows back each block.
+    round(if(count(DISTINCT o.block_number) > 0, sum(o.count) / count(DISTINCT o.block_number), 0), 4) AS avg_count_per_block,
+    round(if(count(DISTINCT o.block_number) > 0, sum(o.gas) / count(DISTINCT o.block_number), 0), 4) AS avg_gas_per_block,
     round(if(sum(o.count) > 0, sum(o.gas) / sum(o.count), 0), 4) AS avg_gas_per_execution
 FROM (SELECT * FROM {{ index .dep "{{transformation}}" "int_block_opcode_gas" "helpers" "from" }} FINAL) AS o
 GLOBAL INNER JOIN blocks_in_days AS b ON o.block_number = b.block_number

--- a/models/transformations/fct_opcode_gas_by_opcode_hourly.sql
+++ b/models/transformations/fct_opcode_gas_by_opcode_hourly.sql
@@ -51,8 +51,12 @@ SELECT
     sum(o.count) AS total_count,
     sum(o.gas) AS total_gas,
     sum(o.error_count) AS total_error_count,
-    round(avg(o.count), 4) AS avg_count_per_block,
-    round(avg(o.gas), 4) AS avg_gas_per_block,
+    -- Compute per-block averages as total / distinct-blocks rather than avg() over the source rows.
+    -- int_block_opcode_gas can carry multiple partial rows per (block, opcode) across shards, so
+    -- avg(o.gas) would divide by the inflated row count; sum()/count(DISTINCT block_number) is the
+    -- true per-block average regardless of how many partial rows back each block.
+    round(if(count(DISTINCT o.block_number) > 0, sum(o.count) / count(DISTINCT o.block_number), 0), 4) AS avg_count_per_block,
+    round(if(count(DISTINCT o.block_number) > 0, sum(o.gas) / count(DISTINCT o.block_number), 0), 4) AS avg_gas_per_block,
     round(if(sum(o.count) > 0, sum(o.gas) / sum(o.count), 0), 4) AS avg_gas_per_execution
 FROM (SELECT * FROM {{ index .dep "{{transformation}}" "int_block_opcode_gas" "helpers" "from" }} FINAL) AS o
 GLOBAL INNER JOIN blocks_in_hours AS b ON o.block_number = b.block_number

--- a/models/transformations/int_execution_block_by_date.sql
+++ b/models/transformations/int_execution_block_by_date.sql
@@ -13,13 +13,28 @@ tags:
   - execution
 dependencies:
   - "{{external}}.canonical_execution_block"
+  - "{{external}}.canonical_execution_transaction"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`
 SELECT
     fromUnixTimestamp({{ .task.start }}) AS updated_date_time,
-    block_date_time,
-    block_number
-FROM {{ index .dep "{{external}}" "canonical_execution_block" "helpers" "from" }} FINAL
-WHERE block_number BETWEEN {{ .bounds.start }} AND {{ .bounds.end }}
-    AND meta_network_name = '{{ .env.NETWORK }}'
+    b.block_date_time,
+    b.block_number,
+    -- Per-block transaction count, aggregated once here (a simple top-level model) so the
+    -- cross-shard count() merges globally. Downstream models (e.g. fct_execution_tps_hourly) read
+    -- this column instead of re-counting the transaction_hash-sharded canonical_execution_transaction
+    -- inside a nested query, where the count would otherwise be evaluated shard-local and partial.
+    toUInt32(COALESCE(t.transaction_count, 0)) AS transaction_count
+FROM {{ index .dep "{{external}}" "canonical_execution_block" "helpers" "from" }} AS b FINAL
+GLOBAL LEFT JOIN (
+    SELECT
+        block_number,
+        count() AS transaction_count
+    FROM {{ index .dep "{{external}}" "canonical_execution_transaction" "helpers" "from" }} FINAL
+    WHERE block_number BETWEEN {{ .bounds.start }} AND {{ .bounds.end }}
+        AND meta_network_name = '{{ .env.NETWORK }}'
+    GROUP BY block_number
+) AS t ON b.block_number = t.block_number
+WHERE b.block_number BETWEEN {{ .bounds.start }} AND {{ .bounds.end }}
+    AND b.meta_network_name = '{{ .env.NETWORK }}'


### PR DESCRIPTION
## Summary

On a **multi-shard** ClickHouse cluster, several transformation models aggregate a sharded source by a grain that does **not** contain the source's sharding columns. Under shard-local execution each shard writes a partial aggregate that `ReplacingMergeTree FINAL` can never re-merge (dedup is per-shard) → duplicated / under-counted rows. (Single-shard deployments hide this — there is only one partial.) This PR re-shards the offending sources so each grain co-locates on one shard, plus a few standalone fixes.

## Changes

### Re-shard sources (shard key ⊆ grain)
| migration | table(s) | sharding key |
|---|---|---|
| `056` / `074` / `076` | the 6 `int_transaction_*` tables | `cityHash64(block_number, transaction_hash)` → `cityHash64(block_number)` |
| `007` | `int_attestation_first_seen` | `(slot_start_date_time, attesting_validator_index)` → `(slot_start_date_time)` |
| `034` | `int_custody_probe` | `(probe_date_time, slot, peer_id_unique_key)` → `(slot, peer_id_unique_key)` |

These fix the per-block EL rollups (`int_block_*` → `fct_opcode_*`, `fct_execution_receipt_size_*`), `fct_attestation_observation_by_node`, and the re-keyed `int_custody_probe_order_by_slot` respectively.

### Other fixes
- **`fct_execution_tps_hourly`** — moved the per-block tx count out of a nested shard-local subquery into a precomputed `int_execution_block_by_date.transaction_count` column (migration `032`; a simple top-level aggregation that merges globally) and look it up. ✅ verified **byte-identical** hourly output vs old on two block ranges (`count` + `sum(cityHash64(*))` checksums match).
- **`fct_opcode_gas_by_opcode_hourly` / `_daily`** — `avg_*_per_block = total / count(DISTINCT block_number)` instead of `avg()` over fragmented rows. ✅ verified new = total/blocks (old under-counted ~2.7–3×).
- **`dim_validator_status`** — `PARTITION BY tuple()` (migration `058`) so `ReplacingMergeTree` can dedup a `(validator_index, status)` key whose window straddles a month boundary.
- **`dim_node.py`** — read `ethseer_validator_entity` via `cluster('{raw}', …)` (the configured remote-cluster macro) instead of `{remote_cluster}`, which doesn't exist and made the query error and silently return 0 rows (the script swallowed the exception), leaving `dim_node` empty and every joined `entity` NULL.

> ⚠️ Migrations are edited **in place** (no new migrations). Placement/partition changes only take effect after the affected tables are **truncated and re-backfilled**.

## Post-merge: TRUNCATE + re-run (dependency order, upstream first)

Transitive downstream closure of every changed table — these hold stale/duplicated data until rebuilt:

```
dim_validator_status
fct_attestation_first_seen_chunked_50ms
fct_attestation_observation_by_node
fct_data_column_availability_by_epoch
fct_data_column_availability_by_slot
fct_data_column_availability_by_slot_blob
fct_data_column_availability_daily
fct_data_column_availability_hourly
fct_execution_receipt_size_daily
fct_execution_receipt_size_hourly
fct_execution_tps_hourly
fct_opcode_gas_by_opcode_daily
fct_opcode_gas_by_opcode_hourly
fct_opcode_ops_daily
fct_opcode_ops_hourly
int_attestation_first_seen
int_block_opcode_gas
int_block_receipt_size
int_block_resource_gas
int_custody_probe
int_custody_probe_order_by_slot
int_execution_block_by_date
int_transaction_call_frame
int_transaction_call_frame_opcode_gas
int_transaction_call_frame_opcode_resource_gas
int_transaction_opcode_gas
int_transaction_receipt_size
int_transaction_resource_gas
```

> Note: `int_execution_block_by_date` only gained an additive `transaction_count` column (existing columns unchanged), so its ~50 other consumers that read only `block_date_time`/`block_number` are **not** listed — only `fct_execution_tps_hourly` (which reads the new column) needs rebuilding from it.

### Also: populate `dim_node`, then re-run its consumers
With the `dim_node.py` fix, **run `dim_node`** (it will now populate from ethseer via `cluster('{raw}', …)`), then truncate + re-run its downstream (currently all carry NULL `entity`):

```
fct_attestation_liveness_by_entity_head
fct_block_proposer_entity
fct_validator_count_by_entity_by_status_daily
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
