### PR TITLE
refactor(infra): rename remote ClickHouse clusters + wire optimize-model creds from .env

### DIFF
--- a/.claude/skills/optimize-model/SKILL.md
+++ b/.claude/skills/optimize-model/SKILL.md
@@ -15,20 +15,47 @@ Never modify the model file. Only report findings and recommendations.
 
 Before any analysis, collect and confirm (allow overrides):
 
+Credentials and endpoint/database overrides are auto-loaded from the project `.env` by the run wrappers
+(`EXTERNAL_USER`/`EXTERNAL_PASS` for the raw cluster, `TRANSFORM_USER`/`TRANSFORM_PASS` for the refined cluster).
+Already-exported shell variables take precedence over `.env`. Note these are the PRODUCTION cluster credentials,
+separate from the local docker `CLICKHOUSE_USERNAME`/`CLICKHOUSE_PASSWORD`.
+
 - External models cluster:
-  - `endpoint`: `http://chendpoint-xatu-clickhouse.analytics.production.ethpandaops:8123`
+  - `endpoint`: `http://chendpoint-clickhouse-raw.analytics.production.ethpandaops:8123`
   - `default_database`: `default`
-  - `username`: empty
-  - `password`: empty
+  - `username`: `EXTERNAL_USER` (from `.env`, default empty)
+  - `password`: `EXTERNAL_PASS` (from `.env`, default empty)
 - Transformation models cluster:
-  - `endpoint`: `http://chendpoint-xatu-cbt-clickhouse.analytics.production.ethpandaops:8123`
+  - `endpoint`: `http://chendpoint-clickhouse-refined.analytics.production.ethpandaops:8123`
   - `default_database`: `mainnet`
-  - `username`: empty
-  - `password`: empty
-  - `access_to_external_cluster`: `cluster('{remote_cluster}', database.table_name)`
+  - `username`: `TRANSFORM_USER` (from `.env`, default empty)
+  - `password`: `TRANSFORM_PASS` (from `.env`, default empty)
+  - `access_to_external_cluster`: `cluster('{raw}', database.table_name)`
   - Cluster substitution rule: when template uses `cluster(...)`, external dependencies are resolved to `<table>_local` automatically.
 
 If any value is missing or ambiguous, ask follow-up questions before running benchmarks.
+
+### Credential preflight (gate before any cluster query)
+
+The raw and refined clusters require authentication, so empty credentials will fail with
+`AUTHENTICATION_FAILED` rather than run anonymously. Before the first `run_prepare.sh`/benchmark call,
+resolve the credentials exactly as the wrappers do and check whether they are populated:
+
+```bash
+bash -c '. .claude/skills/optimize-model/scripts/_load_env.sh; \
+  echo "EXTERNAL=${EXTERNAL_USER:+set} TRANSFORM=${TRANSFORM_USER:+set}"'
+```
+
+If the credentials for a cluster you are about to query are empty, STOP and elicit a choice from the
+user with `AskUserQuestion` (do not silently run and let it fail):
+
+- **Add credentials** — ask the user to populate `EXTERNAL_USER`/`EXTERNAL_PASS` and/or
+  `TRANSFORM_USER`/`TRANSFORM_PASS` in `.env` (or export them), then re-resolve and continue.
+- **Continue unauthenticated** — proceed anyway. Only valid if the target cluster permits anonymous
+  access; otherwise expect the run to fail with `AUTHENTICATION_FAILED`.
+
+Only run the benchmark scripts once the user has chosen. Skip this gate (no prompt) when the needed
+credentials are already present.
 
 ## Inputs
 

--- a/.claude/skills/optimize-model/references/dependency-resolution.md
+++ b/.claude/skills/optimize-model/references/dependency-resolution.md
@@ -18,7 +18,7 @@ Use these rules to convert CBT transformation model templates into a runnable re
 
 ## Substitution
 - External dependency replacement uses configurable template:
-  - Default: `cluster('{remote_cluster}', database.table_name)`
+  - Default: `cluster('{raw}', database.table_name)`
   - Replace `database` and `table_name` with confirmed external database and dependency table.
   - If template uses `cluster(...)`, resolve dependency table to `<table>_local` (not the Distributed table name).
 - Transformation dependency replacement is direct table access:

--- a/.claude/skills/optimize-model/scripts/_load_env.sh
+++ b/.claude/skills/optimize-model/scripts/_load_env.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Load the project .env so optimize-model picks up ClickHouse credentials (and
+# any endpoint/database overrides) without manual exports.
+#
+# Precedence: already-exported environment variables WIN over .env. This means a
+# per-invocation override such as `TRANSFORM_PASS=secret ./run_benchmark.sh ...`
+# still takes effect even if .env also defines TRANSFORM_PASS.
+#
+# Source this near the top of a wrapper, after SCRIPT_DIR is defined:
+#   . "$SCRIPT_DIR/_load_env.sh"
+#
+# Override the file location with ENV_FILE=/path/to/.env if needed.
+# Compatible with Bash 3.2+ (macOS default bash).
+
+# Resolve repo root: scripts/ -> optimize-model/ -> skills/ -> .claude/ -> repo
+__om_env_file="${ENV_FILE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)/.env}"
+
+if [ -f "$__om_env_file" ]; then
+  while IFS= read -r __om_line || [ -n "$__om_line" ]; do
+    # Skip blanks and comments; require KEY=VALUE form.
+    case "$__om_line" in
+      ''|'#'*) continue ;;
+      *=*) : ;;
+      *) continue ;;
+    esac
+    # Strip an optional leading "export ".
+    case "$__om_line" in
+      'export '*) __om_line="${__om_line#export }" ;;
+    esac
+    __om_key="${__om_line%%=*}"
+    # Only accept valid shell identifiers (guards the eval below).
+    case "$__om_key" in
+      ''|[!A-Za-z_]*|*[!A-Za-z0-9_]*) continue ;;
+    esac
+    # Only set if the variable is not already present in the environment.
+    eval "__om_cur=\${$__om_key+x}"
+    if [ -z "${__om_cur:-}" ]; then
+      export "$__om_line"
+    fi
+  done < "$__om_env_file"
+  unset __om_line __om_key __om_cur
+fi
+unset __om_env_file

--- a/.claude/skills/optimize-model/scripts/benchmark_query.py
+++ b/.claude/skills/optimize-model/scripts/benchmark_query.py
@@ -32,7 +32,7 @@ def parse_args() -> argparse.Namespace:
     src.add_argument("--query", help="SQL query string")
     src.add_argument("--query-file", help="Path to SQL query file")
 
-    parser.add_argument("--endpoint", default="http://chendpoint-xatu-cbt-clickhouse.analytics.production.ethpandaops:8123")
+    parser.add_argument("--endpoint", default="http://chendpoint-clickhouse-refined.analytics.production.ethpandaops:8123")
     parser.add_argument("--database", default="mainnet")
     parser.add_argument("--username", default="")
     parser.add_argument("--password", default="")

--- a/.claude/skills/optimize-model/scripts/compare_query_hash.py
+++ b/.claude/skills/optimize-model/scripts/compare_query_hash.py
@@ -36,7 +36,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--baseline-query-file", required=True)
     parser.add_argument("--candidate-query-file", required=True)
-    parser.add_argument("--endpoint", default="http://chendpoint-xatu-cbt-clickhouse.analytics.production.ethpandaops:8123")
+    parser.add_argument("--endpoint", default="http://chendpoint-clickhouse-refined.analytics.production.ethpandaops:8123")
     parser.add_argument("--database", default="mainnet")
     parser.add_argument("--username", default="")
     parser.add_argument("--password", default="")

--- a/.claude/skills/optimize-model/scripts/introspect_tables.py
+++ b/.claude/skills/optimize-model/scripts/introspect_tables.py
@@ -37,12 +37,12 @@ def parse_args() -> argparse.Namespace:
         help="Dependency in kind:table format (e.g. external:canonical_beacon_block)",
     )
 
-    parser.add_argument("--external-endpoint", default="http://chendpoint-xatu-clickhouse.analytics.production.ethpandaops:8123")
+    parser.add_argument("--external-endpoint", default="http://chendpoint-clickhouse-raw.analytics.production.ethpandaops:8123")
     parser.add_argument("--external-database", default="default")
     parser.add_argument("--external-username", default="")
     parser.add_argument("--external-password", default="")
 
-    parser.add_argument("--transformation-endpoint", default="http://chendpoint-xatu-cbt-clickhouse.analytics.production.ethpandaops:8123")
+    parser.add_argument("--transformation-endpoint", default="http://chendpoint-clickhouse-refined.analytics.production.ethpandaops:8123")
     parser.add_argument("--transformation-database", default="mainnet")
     parser.add_argument("--transformation-username", default="")
     parser.add_argument("--transformation-password", default="")

--- a/.claude/skills/optimize-model/scripts/prepare_model_analysis.py
+++ b/.claude/skills/optimize-model/scripts/prepare_model_analysis.py
@@ -38,20 +38,20 @@ def parse_args() -> argparse.Namespace:
 
     parser.add_argument(
         "--external-endpoint",
-        default="http://chendpoint-xatu-clickhouse.analytics.production.ethpandaops:8123",
+        default="http://chendpoint-clickhouse-raw.analytics.production.ethpandaops:8123",
     )
     parser.add_argument("--external-database", default="default")
     parser.add_argument("--external-username", default="")
     parser.add_argument("--external-password", default="")
 
-    parser.add_argument("--transformation-endpoint", default="http://chendpoint-xatu-cbt-clickhouse.analytics.production.ethpandaops:8123")
+    parser.add_argument("--transformation-endpoint", default="http://chendpoint-clickhouse-refined.analytics.production.ethpandaops:8123")
     parser.add_argument("--transformation-database", default="mainnet")
     parser.add_argument("--transformation-username", default="")
     parser.add_argument("--transformation-password", default="")
 
     parser.add_argument(
         "--access-to-external-cluster",
-        default="cluster('{remote_cluster}', database.table_name)",
+        default="cluster('{raw}', database.table_name)",
     )
     parser.add_argument("--network", default="mainnet")
     parser.add_argument("--bounds-start", type=int)

--- a/.claude/skills/optimize-model/scripts/resolve_model_sql.py
+++ b/.claude/skills/optimize-model/scripts/resolve_model_sql.py
@@ -49,7 +49,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--transformation-database", default="mainnet")
     parser.add_argument(
         "--external-template",
-        default="cluster('{remote_cluster}', database.table_name)",
+        default="cluster('{raw}', database.table_name)",
         help="Template used for external dependencies",
     )
     parser.add_argument("--network", default="mainnet")

--- a/.claude/skills/optimize-model/scripts/run_benchmark.sh
+++ b/.claude/skills/optimize-model/scripts/run_benchmark.sh
@@ -13,6 +13,8 @@ if [ ! -f "$PREP_OUTPUT" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Load credentials/overrides from the project .env (exported env wins over .env).
+. "$SCRIPT_DIR/_load_env.sh"
 
 SESSION_ID="${SESSION_ID:-$(python3 - <<'PY' "$PREP_OUTPUT"
 import json,sys
@@ -33,7 +35,7 @@ print(data['paths']['rendered_sql'])
 PY
 )"
 
-TRANSFORM_ENDPOINT="${TRANSFORM_ENDPOINT:-http://chendpoint-xatu-cbt-clickhouse.analytics.production.ethpandaops:8123}"
+TRANSFORM_ENDPOINT="${TRANSFORM_ENDPOINT:-http://chendpoint-clickhouse-refined.analytics.production.ethpandaops:8123}"
 TRANSFORM_DB="${TRANSFORM_DB:-mainnet}"
 TRANSFORM_USER="${TRANSFORM_USER:-}"
 TRANSFORM_PASS="${TRANSFORM_PASS:-}"

--- a/.claude/skills/optimize-model/scripts/run_candidate_benchmark.sh
+++ b/.claude/skills/optimize-model/scripts/run_candidate_benchmark.sh
@@ -19,6 +19,8 @@ if [ ! -f "$CANDIDATE_SQL" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Load credentials/overrides from the project .env (exported env wins over .env).
+. "$SCRIPT_DIR/_load_env.sh"
 
 SESSION_ID="${SESSION_ID:-$(python3 - <<'PY' "$PREP_OUTPUT"
 import json,sys
@@ -31,7 +33,7 @@ if [ -z "$SESSION_ID" ]; then
   SESSION_ID="$(date +%s)-$$"
 fi
 
-TRANSFORM_ENDPOINT="${TRANSFORM_ENDPOINT:-http://chendpoint-xatu-cbt-clickhouse.analytics.production.ethpandaops:8123}"
+TRANSFORM_ENDPOINT="${TRANSFORM_ENDPOINT:-http://chendpoint-clickhouse-refined.analytics.production.ethpandaops:8123}"
 TRANSFORM_DB="${TRANSFORM_DB:-mainnet}"
 TRANSFORM_USER="${TRANSFORM_USER:-}"
 TRANSFORM_PASS="${TRANSFORM_PASS:-}"

--- a/.claude/skills/optimize-model/scripts/run_hash_check.sh
+++ b/.claude/skills/optimize-model/scripts/run_hash_check.sh
@@ -19,6 +19,8 @@ if [ ! -f "$CANDIDATE_SQL" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Load credentials/overrides from the project .env (exported env wins over .env).
+. "$SCRIPT_DIR/_load_env.sh"
 
 SESSION_ID="${SESSION_ID:-$(python3 - <<'PY' "$PREP_OUTPUT"
 import json,sys
@@ -39,7 +41,7 @@ print(data['paths']['rendered_sql'])
 PY
 )}"
 
-TRANSFORM_ENDPOINT="${TRANSFORM_ENDPOINT:-http://chendpoint-xatu-cbt-clickhouse.analytics.production.ethpandaops:8123}"
+TRANSFORM_ENDPOINT="${TRANSFORM_ENDPOINT:-http://chendpoint-clickhouse-refined.analytics.production.ethpandaops:8123}"
 TRANSFORM_DB="${TRANSFORM_DB:-mainnet}"
 TRANSFORM_USER="${TRANSFORM_USER:-}"
 TRANSFORM_PASS="${TRANSFORM_PASS:-}"

--- a/.claude/skills/optimize-model/scripts/run_prepare.sh
+++ b/.claude/skills/optimize-model/scripts/run_prepare.sh
@@ -9,22 +9,24 @@ if [ -z "$MODEL" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Load credentials/overrides from the project .env (exported env wins over .env).
+. "$SCRIPT_DIR/_load_env.sh"
 REPO_ROOT="${REPO_ROOT:-.}"
 SESSION_ID="${SESSION_ID:-$(date +%s)-$$}"
 PERIOD_MODE="${PERIOD_MODE:-sane}"
 PREP_OUTPUT="${PREP_OUTPUT:-/tmp/optimize-model.${SESSION_ID}.prepare.json}"
 
-EXTERNAL_ENDPOINT="${EXTERNAL_ENDPOINT:-http://chendpoint-xatu-clickhouse.analytics.production.ethpandaops:8123}"
+EXTERNAL_ENDPOINT="${EXTERNAL_ENDPOINT:-http://chendpoint-clickhouse-raw.analytics.production.ethpandaops:8123}"
 EXTERNAL_DB="${EXTERNAL_DB:-default}"
 EXTERNAL_USER="${EXTERNAL_USER:-}"
 EXTERNAL_PASS="${EXTERNAL_PASS:-}"
 
-TRANSFORM_ENDPOINT="${TRANSFORM_ENDPOINT:-http://chendpoint-xatu-cbt-clickhouse.analytics.production.ethpandaops:8123}"
+TRANSFORM_ENDPOINT="${TRANSFORM_ENDPOINT:-http://chendpoint-clickhouse-refined.analytics.production.ethpandaops:8123}"
 TRANSFORM_DB="${TRANSFORM_DB:-mainnet}"
 TRANSFORM_USER="${TRANSFORM_USER:-}"
 TRANSFORM_PASS="${TRANSFORM_PASS:-}"
 
-ACCESS_TO_EXTERNAL_CLUSTER="${ACCESS_TO_EXTERNAL_CLUSTER:-cluster('{remote_cluster}', database.table_name)}"
+ACCESS_TO_EXTERNAL_CLUSTER="${ACCESS_TO_EXTERNAL_CLUSTER:-cluster('{raw}', database.table_name)}"
 NETWORK="${NETWORK:-mainnet}"
 TIMEOUT="${TIMEOUT:-30}"
 

--- a/example.env
+++ b/example.env
@@ -12,6 +12,15 @@ CLICKHOUSE_PASSWORD=supersecret
 CLICKHOUSE_CLUSTER={cluster}
 CLICKHOUSE_VERSION=25.5.10
 
+# optimize-model skill credentials (PRODUCTION clusters, auto-loaded by .claude/skills/optimize-model).
+# These are SEPARATE from CLICKHOUSE_USERNAME/PASSWORD above (which are the local docker stack).
+# EXTERNAL_* -> raw cluster (chendpoint-clickhouse-raw); TRANSFORM_* -> refined cluster (chendpoint-clickhouse-refined).
+# Leave blank for unauthenticated access. Exported shell vars override these per-invocation.
+EXTERNAL_USER=
+EXTERNAL_PASS=
+TRANSFORM_USER=
+TRANSFORM_PASS=
+
 # CBT Cluster Ports (docker-compose.platform.yml - transformations/test data)
 CLICKHOUSE_CBT_01_HTTP_PORT=8123
 CLICKHOUSE_CBT_01_NATIVE_PORT=9000

--- a/internal/infra/clickhouse_config.go
+++ b/internal/infra/clickhouse_config.go
@@ -33,15 +33,15 @@ type ShardDefinition struct {
 
 // ClusterTopology defines the complete topology of a known cluster.
 type ClusterTopology struct {
-	HostPrefix string            // e.g., "chendpoint-xatu-clickhouse"
+	HostPrefix string            // e.g., "chendpoint-clickhouse-raw"
 	Shards     []ShardDefinition // Shard definitions with replica suffixes
 }
 
 // knownClusters maps hostname prefixes to their cluster topologies.
 // When a hostname matches a prefix, the full topology is used for config generation.
 var knownClusters = map[string]ClusterTopology{
-	"chendpoint-xatu-clickhouse": {
-		HostPrefix: "chendpoint-xatu-clickhouse",
+	"chendpoint-clickhouse-raw": {
+		HostPrefix: "chendpoint-clickhouse-raw",
 		Shards: []ShardDefinition{
 			{Replicas: []ReplicaDefinition{{HostSuffix: "-0-0"}, {HostSuffix: "-0-1"}}},
 			{Replicas: []ReplicaDefinition{{HostSuffix: "-1-0"}, {HostSuffix: "-1-1"}}},
@@ -57,7 +57,7 @@ type ExpandedTopology struct {
 
 // ExpandedShard contains fully resolved replica hostnames for a shard.
 type ExpandedShard struct {
-	Replicas []string // Full hostnames, e.g., "chendpoint-xatu-clickhouse-0-0.analytics.production.ethpandaops"
+	Replicas []string // Full hostnames, e.g., "chendpoint-clickhouse-raw-0-0.analytics.production.ethpandaops"
 }
 
 // detectClusterTopology checks if the hostname matches a known cluster pattern.
@@ -352,7 +352,7 @@ const clickhouseConfigTemplate = `<clickhouse replace="true">
 // This creates config files in local-config/clickhouse-external/ with the xatu_cluster configured
 // to point to the provided external ClickHouse connection details.
 //
-// For known cluster patterns (e.g., chendpoint-xatu-clickhouse), it automatically expands
+// For known cluster patterns (e.g., chendpoint-clickhouse-raw), it automatically expands
 // to include all shards and replicas. For unknown clusters, it uses a single-endpoint config.
 func GenerateExternalClickHouseConfig(log logrus.FieldLogger, host string, port int, username, password string, secure bool) error {
 	if host == "" {

--- a/internal/infra/clickhouse_config_test.go
+++ b/internal/infra/clickhouse_config_test.go
@@ -30,13 +30,13 @@ func TestDetectClusterTopology(t *testing.T) {
 	}{
 		{
 			name:           "known production cluster",
-			hostname:       "chendpoint-xatu-clickhouse.analytics.production.ethpandaops",
+			hostname:       "chendpoint-clickhouse-raw.analytics.production.ethpandaops",
 			expectTopology: true,
 			expectedShards: 3,
 		},
 		{
 			name:           "known cluster with different domain",
-			hostname:       "chendpoint-xatu-clickhouse.some.other.domain",
+			hostname:       "chendpoint-clickhouse-raw.some.other.domain",
 			expectTopology: true,
 			expectedShards: 3,
 		},
@@ -48,7 +48,7 @@ func TestDetectClusterTopology(t *testing.T) {
 		},
 		{
 			name:           "no domain suffix",
-			hostname:       "chendpoint-xatu-clickhouse",
+			hostname:       "chendpoint-clickhouse-raw",
 			expectTopology: false,
 			expectedShards: 0,
 		},
@@ -94,21 +94,21 @@ func TestDetectClusterTopology(t *testing.T) {
 func TestDetectClusterTopology_ExpandedHostnames(t *testing.T) {
 	log := newTestLogger()
 
-	topology := detectClusterTopology(log, "chendpoint-xatu-clickhouse.analytics.production.ethpandaops")
+	topology := detectClusterTopology(log, "chendpoint-clickhouse-raw.analytics.production.ethpandaops")
 	require.NotNil(t, topology)
 
 	expectedHosts := [][]string{
 		{
-			"chendpoint-xatu-clickhouse-0-0.analytics.production.ethpandaops",
-			"chendpoint-xatu-clickhouse-0-1.analytics.production.ethpandaops",
+			"chendpoint-clickhouse-raw-0-0.analytics.production.ethpandaops",
+			"chendpoint-clickhouse-raw-0-1.analytics.production.ethpandaops",
 		},
 		{
-			"chendpoint-xatu-clickhouse-1-0.analytics.production.ethpandaops",
-			"chendpoint-xatu-clickhouse-1-1.analytics.production.ethpandaops",
+			"chendpoint-clickhouse-raw-1-0.analytics.production.ethpandaops",
+			"chendpoint-clickhouse-raw-1-1.analytics.production.ethpandaops",
 		},
 		{
-			"chendpoint-xatu-clickhouse-2-0.analytics.production.ethpandaops",
-			"chendpoint-xatu-clickhouse-2-1.analytics.production.ethpandaops",
+			"chendpoint-clickhouse-raw-2-0.analytics.production.ethpandaops",
+			"chendpoint-clickhouse-raw-2-1.analytics.production.ethpandaops",
 		},
 	}
 
@@ -324,7 +324,7 @@ func TestGenerateExternalClickHouseConfig_Integration(t *testing.T) {
 	t.Run("multi-shard config for known cluster", func(t *testing.T) {
 		err := GenerateExternalClickHouseConfig(
 			log,
-			"chendpoint-xatu-clickhouse.analytics.production.ethpandaops",
+			"chendpoint-clickhouse-raw.analytics.production.ethpandaops",
 			9000,
 			"",
 			"",
@@ -341,12 +341,12 @@ func TestGenerateExternalClickHouseConfig_Integration(t *testing.T) {
 			xml := string(content)
 
 			// Should have all 6 shard endpoints
-			assert.Contains(t, xml, "chendpoint-xatu-clickhouse-0-0.analytics.production.ethpandaops")
-			assert.Contains(t, xml, "chendpoint-xatu-clickhouse-0-1.analytics.production.ethpandaops")
-			assert.Contains(t, xml, "chendpoint-xatu-clickhouse-1-0.analytics.production.ethpandaops")
-			assert.Contains(t, xml, "chendpoint-xatu-clickhouse-1-1.analytics.production.ethpandaops")
-			assert.Contains(t, xml, "chendpoint-xatu-clickhouse-2-0.analytics.production.ethpandaops")
-			assert.Contains(t, xml, "chendpoint-xatu-clickhouse-2-1.analytics.production.ethpandaops")
+			assert.Contains(t, xml, "chendpoint-clickhouse-raw-0-0.analytics.production.ethpandaops")
+			assert.Contains(t, xml, "chendpoint-clickhouse-raw-0-1.analytics.production.ethpandaops")
+			assert.Contains(t, xml, "chendpoint-clickhouse-raw-1-0.analytics.production.ethpandaops")
+			assert.Contains(t, xml, "chendpoint-clickhouse-raw-1-1.analytics.production.ethpandaops")
+			assert.Contains(t, xml, "chendpoint-clickhouse-raw-2-0.analytics.production.ethpandaops")
+			assert.Contains(t, xml, "chendpoint-clickhouse-raw-2-1.analytics.production.ethpandaops")
 
 			// Should have 3 shards in xatu_cluster
 			xatuClusterStart := strings.Index(xml, "<xatu_cluster>")
@@ -481,10 +481,10 @@ func TestGenerateExternalClickHouseConfigFromURL(t *testing.T) {
 
 func TestKnownClusters(t *testing.T) {
 	// Verify the knownClusters map is properly configured
-	cluster, ok := knownClusters["chendpoint-xatu-clickhouse"]
-	require.True(t, ok, "chendpoint-xatu-clickhouse should be in knownClusters")
+	cluster, ok := knownClusters["chendpoint-clickhouse-raw"]
+	require.True(t, ok, "chendpoint-clickhouse-raw should be in knownClusters")
 
-	assert.Equal(t, "chendpoint-xatu-clickhouse", cluster.HostPrefix)
+	assert.Equal(t, "chendpoint-clickhouse-raw", cluster.HostPrefix)
 	assert.Equal(t, 3, len(cluster.Shards), "should have 3 shards")
 
 	// Verify shard structure


### PR DESCRIPTION
## Summary

Two related changes, both scoped to the **remote/production** ClickHouse clusters and the `optimize-model` skill. **The local docker-compose stack is intentionally untouched** (still `xatu-clickhouse-*` / `xatu-cbt-clickhouse-*`).

### 1. Remote cluster rename

Align the production cluster identifiers with their new names:

| Old (prod) | New (prod) | Role |
|---|---|---|
| `chendpoint-xatu-clickhouse` | `chendpoint-clickhouse-raw` | raw / external data |
| `chendpoint-xatu-cbt-clickhouse` | `chendpoint-clickhouse-refined` | refined / transformations |

These match the actual cluster resources (`chi-clickhouse-raw-replicated-*` / `chi-clickhouse-refined-replicated-*`) and are consistent with the equivalent rename already merged in `xcli`.

Changed:
- `internal/infra/clickhouse_config.go` — `knownClusters` topology-detection prefix + doc comments (used by `GenerateExternalClickHouseConfig` to expand a host into shard/replica endpoints).
- `internal/infra/clickhouse_config_test.go` — expected raw-cluster hostnames for topology/XML tests.
- `.claude/skills/optimize-model/**` — default `EXTERNAL_ENDPOINT` (raw) / `TRANSFORM_ENDPOINT` (refined) in the `run_*.sh` wrappers and the Python defaults, plus the cluster access macro `cluster('{remote_cluster}', …)` → `cluster('{raw}', …)`.

### 2. optimize-model credentials from `.env`

The skill targets the **production** clusters, which require auth — previously creds had to be exported manually each run.

- **`scripts/_load_env.sh`** (new) — sources the project `.env` so the wrappers pick up credentials/overrides automatically. Already-exported shell vars take precedence, so `TRANSFORM_PASS=… ./run_benchmark.sh` still overrides per-invocation.
- The four `run_*.sh` wrappers source the loader after `SCRIPT_DIR` is set (they already read `EXTERNAL_*` / `TRANSFORM_*`, so no arg plumbing changed).
- **`example.env`** — documents `EXTERNAL_USER/PASS` (raw) and `TRANSFORM_USER/PASS` (refined), explicitly **separate** from the local docker `CLICKHOUSE_USERNAME/PASSWORD`. Values are blank; real secrets live only in the gitignored `.env`.
- **`SKILL.md`** — documents the `.env` auto-load + precedence, and adds a **credential preflight gate**: when the required creds are empty, the skill stops and elicits an *"add credentials / continue unauthenticated"* choice via `AskUserQuestion` instead of silently failing with `AUTHENTICATION_FAILED`.

## Notes
- No secrets are committed — `.env` is gitignored; only the blank, documented block in `example.env` is included.
- Local dev stack naming is unchanged from `master`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/infra/`
- [x] `bash -n` on all wrappers + `_load_env.sh`
- [x] Loader verified: `.env` values load; exported shell vars override; default path resolves to repo `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
