### PR TITLE
fix(migrations): align int model column order + codecs with prod

### DIFF
--- a/migrations/074_resource_gas.up.sql
+++ b/migrations/074_resource_gas.up.sql
@@ -11,12 +11,12 @@ ALTER TABLE `${NETWORK_NAME}`.int_transaction_call_frame_opcode_gas_local ON CLU
     ADD COLUMN IF NOT EXISTS `cold_access_count` UInt64 DEFAULT 0 COMMENT 'Number of cold storage/account accesses (EIP-2929).' CODEC(ZSTD(1)) AFTER `memory_expansion_gas`;
 
 ALTER TABLE `${NETWORK_NAME}`.int_transaction_call_frame_opcode_gas ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS `memory_words_sum_before` UInt64 DEFAULT 0 COMMENT 'SUM(ceil(memory_bytes/32)) before each opcode executes.' CODEC(ZSTD(1)) AFTER `gas_cumulative`,
-    ADD COLUMN IF NOT EXISTS `memory_words_sum_after` UInt64 DEFAULT 0 COMMENT 'SUM(ceil(memory_bytes/32)) after each opcode executes.' CODEC(ZSTD(1)) AFTER `memory_words_sum_before`,
-    ADD COLUMN IF NOT EXISTS `memory_words_sq_sum_before` UInt64 DEFAULT 0 COMMENT 'SUM(words_before²).' CODEC(ZSTD(1)) AFTER `memory_words_sum_after`,
-    ADD COLUMN IF NOT EXISTS `memory_words_sq_sum_after` UInt64 DEFAULT 0 COMMENT 'SUM(words_after²).' CODEC(ZSTD(1)) AFTER `memory_words_sq_sum_before`,
-    ADD COLUMN IF NOT EXISTS `memory_expansion_gas` UInt64 DEFAULT 0 COMMENT 'SUM(memory_expansion_gas). Exact per-opcode memory expansion cost.' CODEC(ZSTD(1)) AFTER `memory_words_sq_sum_after`,
-    ADD COLUMN IF NOT EXISTS `cold_access_count` UInt64 DEFAULT 0 COMMENT 'Number of cold storage/account accesses (EIP-2929).' CODEC(ZSTD(1)) AFTER `memory_expansion_gas`;
+    ADD COLUMN IF NOT EXISTS `memory_words_sum_before` UInt64 DEFAULT 0 COMMENT 'SUM(ceil(memory_bytes/32)) before each opcode executes.' AFTER `gas_cumulative`,
+    ADD COLUMN IF NOT EXISTS `memory_words_sum_after` UInt64 DEFAULT 0 COMMENT 'SUM(ceil(memory_bytes/32)) after each opcode executes.' AFTER `memory_words_sum_before`,
+    ADD COLUMN IF NOT EXISTS `memory_words_sq_sum_before` UInt64 DEFAULT 0 COMMENT 'SUM(words_before²).' AFTER `memory_words_sum_after`,
+    ADD COLUMN IF NOT EXISTS `memory_words_sq_sum_after` UInt64 DEFAULT 0 COMMENT 'SUM(words_after²).' AFTER `memory_words_sq_sum_before`,
+    ADD COLUMN IF NOT EXISTS `memory_expansion_gas` UInt64 DEFAULT 0 COMMENT 'SUM(memory_expansion_gas). Exact per-opcode memory expansion cost.' AFTER `memory_words_sq_sum_after`,
+    ADD COLUMN IF NOT EXISTS `cold_access_count` UInt64 DEFAULT 0 COMMENT 'Number of cold storage/account accesses (EIP-2929).' AFTER `memory_expansion_gas`;
 
 -- =============================================================================
 -- int_transaction_call_frame_opcode_resource_gas

--- a/migrations/074_resource_gas.up.sql
+++ b/migrations/074_resource_gas.up.sql
@@ -3,7 +3,7 @@
 -- without needing per-opcode structlog data.
 
 ALTER TABLE `${NETWORK_NAME}`.int_transaction_call_frame_opcode_gas_local ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS `memory_words_sum_before` UInt64 DEFAULT 0 COMMENT 'SUM(ceil(memory_bytes/32)) before each opcode executes.' CODEC(ZSTD(1)) AFTER `error_count`,
+    ADD COLUMN IF NOT EXISTS `memory_words_sum_before` UInt64 DEFAULT 0 COMMENT 'SUM(ceil(memory_bytes/32)) before each opcode executes.' CODEC(ZSTD(1)) AFTER `gas_cumulative`,
     ADD COLUMN IF NOT EXISTS `memory_words_sum_after` UInt64 DEFAULT 0 COMMENT 'SUM(ceil(memory_bytes/32)) after each opcode executes.' CODEC(ZSTD(1)) AFTER `memory_words_sum_before`,
     ADD COLUMN IF NOT EXISTS `memory_words_sq_sum_before` UInt64 DEFAULT 0 COMMENT 'SUM(words_before²).' CODEC(ZSTD(1)) AFTER `memory_words_sum_after`,
     ADD COLUMN IF NOT EXISTS `memory_words_sq_sum_after` UInt64 DEFAULT 0 COMMENT 'SUM(words_after²).' CODEC(ZSTD(1)) AFTER `memory_words_sq_sum_before`,
@@ -11,12 +11,12 @@ ALTER TABLE `${NETWORK_NAME}`.int_transaction_call_frame_opcode_gas_local ON CLU
     ADD COLUMN IF NOT EXISTS `cold_access_count` UInt64 DEFAULT 0 COMMENT 'Number of cold storage/account accesses (EIP-2929).' CODEC(ZSTD(1)) AFTER `memory_expansion_gas`;
 
 ALTER TABLE `${NETWORK_NAME}`.int_transaction_call_frame_opcode_gas ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS `memory_words_sum_before` UInt64 DEFAULT 0 COMMENT 'SUM(ceil(memory_bytes/32)) before each opcode executes.' AFTER `error_count`,
-    ADD COLUMN IF NOT EXISTS `memory_words_sum_after` UInt64 DEFAULT 0 COMMENT 'SUM(ceil(memory_bytes/32)) after each opcode executes.' AFTER `memory_words_sum_before`,
-    ADD COLUMN IF NOT EXISTS `memory_words_sq_sum_before` UInt64 DEFAULT 0 COMMENT 'SUM(words_before²).' AFTER `memory_words_sum_after`,
-    ADD COLUMN IF NOT EXISTS `memory_words_sq_sum_after` UInt64 DEFAULT 0 COMMENT 'SUM(words_after²).' AFTER `memory_words_sq_sum_before`,
-    ADD COLUMN IF NOT EXISTS `memory_expansion_gas` UInt64 DEFAULT 0 COMMENT 'SUM(memory_expansion_gas). Exact per-opcode memory expansion cost.' AFTER `memory_words_sq_sum_after`,
-    ADD COLUMN IF NOT EXISTS `cold_access_count` UInt64 DEFAULT 0 COMMENT 'Number of cold storage/account accesses (EIP-2929).' AFTER `memory_expansion_gas`;
+    ADD COLUMN IF NOT EXISTS `memory_words_sum_before` UInt64 DEFAULT 0 COMMENT 'SUM(ceil(memory_bytes/32)) before each opcode executes.' CODEC(ZSTD(1)) AFTER `gas_cumulative`,
+    ADD COLUMN IF NOT EXISTS `memory_words_sum_after` UInt64 DEFAULT 0 COMMENT 'SUM(ceil(memory_bytes/32)) after each opcode executes.' CODEC(ZSTD(1)) AFTER `memory_words_sum_before`,
+    ADD COLUMN IF NOT EXISTS `memory_words_sq_sum_before` UInt64 DEFAULT 0 COMMENT 'SUM(words_before²).' CODEC(ZSTD(1)) AFTER `memory_words_sum_after`,
+    ADD COLUMN IF NOT EXISTS `memory_words_sq_sum_after` UInt64 DEFAULT 0 COMMENT 'SUM(words_after²).' CODEC(ZSTD(1)) AFTER `memory_words_sq_sum_before`,
+    ADD COLUMN IF NOT EXISTS `memory_expansion_gas` UInt64 DEFAULT 0 COMMENT 'SUM(memory_expansion_gas). Exact per-opcode memory expansion cost.' CODEC(ZSTD(1)) AFTER `memory_words_sq_sum_after`,
+    ADD COLUMN IF NOT EXISTS `cold_access_count` UInt64 DEFAULT 0 COMMENT 'Number of cold storage/account accesses (EIP-2929).' CODEC(ZSTD(1)) AFTER `memory_expansion_gas`;
 
 -- =============================================================================
 -- int_transaction_call_frame_opcode_resource_gas

--- a/migrations/077_int_attestation_first_seen_votes.up.sql
+++ b/migrations/077_int_attestation_first_seen_votes.up.sql
@@ -5,7 +5,7 @@ ALTER TABLE `${NETWORK_NAME}`.int_attestation_first_seen_local ON CLUSTER '{clus
     ADD COLUMN IF NOT EXISTS `target_root` String COMMENT 'Target checkpoint root of the attestation' CODEC(ZSTD(1)) AFTER `target_epoch`;
 
 ALTER TABLE `${NETWORK_NAME}`.int_attestation_first_seen ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS `source_epoch` UInt32 COMMENT 'Source checkpoint epoch of the attestation' CODEC(DoubleDelta, ZSTD(1)) AFTER `attesting_validator_committee_index`,
-    ADD COLUMN IF NOT EXISTS `source_root` String COMMENT 'Source checkpoint root of the attestation' CODEC(ZSTD(1)) AFTER `source_epoch`,
-    ADD COLUMN IF NOT EXISTS `target_epoch` UInt32 COMMENT 'Target checkpoint epoch of the attestation' CODEC(DoubleDelta, ZSTD(1)) AFTER `source_root`,
-    ADD COLUMN IF NOT EXISTS `target_root` String COMMENT 'Target checkpoint root of the attestation' CODEC(ZSTD(1)) AFTER `target_epoch`;
+    ADD COLUMN IF NOT EXISTS `source_epoch` UInt32 COMMENT 'Source checkpoint epoch of the attestation' AFTER `attesting_validator_committee_index`,
+    ADD COLUMN IF NOT EXISTS `source_root` String COMMENT 'Source checkpoint root of the attestation' AFTER `source_epoch`,
+    ADD COLUMN IF NOT EXISTS `target_epoch` UInt32 COMMENT 'Target checkpoint epoch of the attestation' AFTER `source_root`,
+    ADD COLUMN IF NOT EXISTS `target_root` String COMMENT 'Target checkpoint root of the attestation' AFTER `target_epoch`;

--- a/migrations/077_int_attestation_first_seen_votes.up.sql
+++ b/migrations/077_int_attestation_first_seen_votes.up.sql
@@ -1,11 +1,11 @@
 ALTER TABLE `${NETWORK_NAME}`.int_attestation_first_seen_local ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS `source_epoch` UInt32 COMMENT 'Source checkpoint epoch of the attestation' CODEC(DoubleDelta, ZSTD(1)),
-    ADD COLUMN IF NOT EXISTS `source_root` String COMMENT 'Source checkpoint root of the attestation' CODEC(ZSTD(1)),
-    ADD COLUMN IF NOT EXISTS `target_epoch` UInt32 COMMENT 'Target checkpoint epoch of the attestation' CODEC(DoubleDelta, ZSTD(1)),
-    ADD COLUMN IF NOT EXISTS `target_root` String COMMENT 'Target checkpoint root of the attestation' CODEC(ZSTD(1));
+    ADD COLUMN IF NOT EXISTS `source_epoch` UInt32 COMMENT 'Source checkpoint epoch of the attestation' CODEC(DoubleDelta, ZSTD(1)) AFTER `attesting_validator_committee_index`,
+    ADD COLUMN IF NOT EXISTS `source_root` String COMMENT 'Source checkpoint root of the attestation' CODEC(ZSTD(1)) AFTER `source_epoch`,
+    ADD COLUMN IF NOT EXISTS `target_epoch` UInt32 COMMENT 'Target checkpoint epoch of the attestation' CODEC(DoubleDelta, ZSTD(1)) AFTER `source_root`,
+    ADD COLUMN IF NOT EXISTS `target_root` String COMMENT 'Target checkpoint root of the attestation' CODEC(ZSTD(1)) AFTER `target_epoch`;
 
 ALTER TABLE `${NETWORK_NAME}`.int_attestation_first_seen ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS `source_epoch` UInt32 COMMENT 'Source checkpoint epoch of the attestation',
-    ADD COLUMN IF NOT EXISTS `source_root` String COMMENT 'Source checkpoint root of the attestation',
-    ADD COLUMN IF NOT EXISTS `target_epoch` UInt32 COMMENT 'Target checkpoint epoch of the attestation',
-    ADD COLUMN IF NOT EXISTS `target_root` String COMMENT 'Target checkpoint root of the attestation';
+    ADD COLUMN IF NOT EXISTS `source_epoch` UInt32 COMMENT 'Source checkpoint epoch of the attestation' CODEC(DoubleDelta, ZSTD(1)) AFTER `attesting_validator_committee_index`,
+    ADD COLUMN IF NOT EXISTS `source_root` String COMMENT 'Source checkpoint root of the attestation' CODEC(ZSTD(1)) AFTER `source_epoch`,
+    ADD COLUMN IF NOT EXISTS `target_epoch` UInt32 COMMENT 'Target checkpoint epoch of the attestation' CODEC(DoubleDelta, ZSTD(1)) AFTER `source_root`,
+    ADD COLUMN IF NOT EXISTS `target_root` String COMMENT 'Target checkpoint root of the attestation' CODEC(ZSTD(1)) AFTER `target_epoch`;

--- a/models/transformations/int_attestation_first_seen.sql
+++ b/models/transformations/int_attestation_first_seen.sql
@@ -105,6 +105,10 @@ SELECT
     argMin(beacon_block_root, propagation_slot_start_diff) AS block_root,
     attesting_validator_index,
     argMin(attesting_validator_committee_index, propagation_slot_start_diff) AS attesting_validator_committee_index,
+    argMin(source_epoch, propagation_slot_start_diff) AS source_epoch,
+    argMin(source_root, propagation_slot_start_diff) AS source_root,
+    argMin(target_epoch, propagation_slot_start_diff) AS target_epoch,
+    argMin(target_root, propagation_slot_start_diff) AS target_root,
     CASE
         WHEN startsWith(meta_client_name, 'pub-') THEN
             splitByChar('/', meta_client_name)[2]
@@ -143,14 +147,6 @@ SELECT
     argMin(meta_client_geo_autonomous_system_number, propagation_slot_start_diff) AS meta_client_geo_autonomous_system_number,
     argMin(meta_client_geo_autonomous_system_organization, propagation_slot_start_diff) AS meta_client_geo_autonomous_system_organization,
     argMin(meta_consensus_version, propagation_slot_start_diff) AS meta_consensus_version,
-    argMin(meta_consensus_implementation, propagation_slot_start_diff) AS meta_consensus_implementation,
-    -- Vote columns were added by migration 077 with a plain ADD COLUMN (no AFTER), so they
-    -- live at the END of the table. This INSERT has no explicit column list, so the SELECT
-    -- must emit them last to line up positionally (otherwise meta_consensus_version lands in
-    -- target_epoch and fails to parse).
-    argMin(source_epoch, propagation_slot_start_diff) AS source_epoch,
-    argMin(source_root, propagation_slot_start_diff) AS source_root,
-    argMin(target_epoch, propagation_slot_start_diff) AS target_epoch,
-    argMin(target_root, propagation_slot_start_diff) AS target_root
+    argMin(meta_consensus_implementation, propagation_slot_start_diff) AS meta_consensus_implementation
 FROM combined_events
 GROUP BY slot_start_date_time, attesting_validator_index

--- a/models/transformations/int_storage_slot_lifecycle_boundary.sql
+++ b/models/transformations/int_storage_slot_lifecycle_boundary.sql
@@ -115,6 +115,6 @@ FROM lifecycle_boundaries
 SETTINGS
     max_bytes_before_external_sort = 10000000000,
     max_bytes_before_external_group_by = 10000000000,
-    max_threads = 8,
+    max_threads = 16,
     distributed_aggregation_memory_efficient = 1,
     join_algorithm = 'parallel_hash';

--- a/models/transformations/int_transaction_call_frame_opcode_gas.sql
+++ b/models/transformations/int_transaction_call_frame_opcode_gas.sql
@@ -68,13 +68,13 @@ SELECT
     opcode_count AS count,
     gas,
     gas_cumulative,
-    error_count,
     memory_words_sum_before,
     memory_words_sum_after,
     memory_words_sq_sum_before,
     memory_words_sq_sum_after,
     memory_expansion_gas,
     cold_access_count,
+    error_count,
     meta_network_name
 FROM {{ index .dep "{{external}}" "canonical_execution_transaction_structlog_agg" "helpers" "from" }}
 WHERE block_number BETWEEN {{ .bounds.start }} AND {{ .bounds.end }}


### PR DESCRIPTION
## Summary

A full schema diff of the `mainnet` database between the **local dev cluster** (built from these migrations) and the **production refined cluster** found drift on exactly **2 of 374 models** — every other table (engines, partition/sorting/primary/sampling keys, and all columns) is byte-identical.

Root cause for both: columns added by a later `ALTER … ADD COLUMN` were **appended after the then-last column**, whereas prod was provisioned from a consolidated schema with the new columns in their logical position. So the repo/local layout drifted from prod's column order.

This PR retro-updates the two migrations to reproduce prod's column **order**, and reorders the corresponding model projections to keep the positional `INSERT` aligned.

## Tables that differed

| Model (+ `_local`) | Migration | Order diff |
|---|---|---|
| `int_attestation_first_seen` | `077` | `source/target_epoch/root` at end → after `attesting_validator_committee_index` |
| `int_transaction_call_frame_opcode_gas` | `074` | `error_count` mid-table → last before `meta_network_name` |

## Changes

**`migrations/077_…votes.up.sql`** — add `AFTER` clauses so the 4 vote columns land after `attesting_validator_committee_index` on both `_local` and Distributed.

**`migrations/074_resource_gas.up.sql`** — insert the 6 resource-gas columns `AFTER gas_cumulative` (instead of `AFTER error_count`), so `error_count` stays last — matching prod.

**Models** (`int_attestation_first_seen.sql`, `int_transaction_call_frame_opcode_gas.sql`) — reorder the SELECT projections to match the reordered tables. All 179 models use positional `INSERT … SELECT` (no column list), so SELECT order must equal the table's physical column order. For `opcode_gas` this matters silently — every shifted column is `UInt64`, so a misaligned positional insert would corrupt data without erroring.

**`models/transformations/int_storage_slot_lifecycle_boundary.sql`** — bump `max_threads` 8 → 16.

## Why no codecs on the Distributed `ALTER`s

CODECs are a storage-layer concept; the Distributed engine stores no data, so codecs there are meaningless. They only show on prod's Distributed tables as an artifact of `CREATE … AS …_local` copying column defs. The `_local` MergeTree tables keep their codecs; the Distributed `ALTER`s carry only the reordering.

## Caveats

- ⚠️ **Fresh deployments only.** Migrations are immutable once applied — `golang-migrate` won't re-run `074`/`077`, and `IF NOT EXISTS + AFTER` can't reposition an existing column. Existing clusters keep the old order until rebuilt. Because the models now emit the new order, any cluster the models run against must be on the new column order (i.e. rebuilt with these migrations).
- Column *set* and types were already identical across clusters, so the only risk was positional `INSERT … SELECT` / `SELECT *`.
- `.down.sql` untouched (DROP is position-independent).

## Tests

No test changes needed — both model test definitions assert by column **name** in SQL (not by position or `SELECT *`), and the `external_data` parquets are inputs, not output snapshots. Reordering is transparent to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)