### PR TITLE
fix: head_correct for missed/orphaned slots in attestation vote correctness

### DIFF
--- a/models/transformations/fct_attestation_vote_correctness_by_validator.sql
+++ b/models/transformations/fct_attestation_vote_correctness_by_validator.sql
@@ -80,6 +80,20 @@ WITH
           AND slot_start_date_time <= fromUnixTimestamp({{ .bounds.end }})
     ),
 
+    -- Canonical head expected at each slot: the most recent canonical block at or
+    -- before the slot. For slots whose own block is missed or orphaned this resolves
+    -- to the previous canonical block, matching the consensus spec's
+    -- get_block_root_at_slot - where attesting to the prior block is the correct
+    -- head vote for an empty slot.
+    slot_canonical_head AS (
+        SELECT
+            slot,
+            anyLast(if(`status` = 'canonical', block_root, NULL))
+                OVER (ORDER BY slot ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                AS canonical_head_root
+        FROM blocks
+    ),
+
     -- Canonical target blocks: the block at the epoch boundary (first slot of epoch),
     -- or if that slot is missed, the last block from the previous epoch
     epoch_blocks AS (
@@ -126,12 +140,15 @@ SELECT
     duties.attesting_validator_index AS validator_index,
     -- Whether attested (not missed)
     attestations.head_root IS NOT NULL AS attested,
-    -- Head correctness: slot_distance = 0 means correct head vote
+    -- Head correctness: did the validator vote the canonical head for its slot?
+    -- The canonical head is the most recent canonical block at or before the slot,
+    -- so a vote for the previous block on a missed or orphaned slot is correct
+    -- (per get_block_root_at_slot in the consensus spec).
     CASE
         WHEN attestations.head_root IS NULL THEN NULL
-        WHEN blocks.slot IS NOT NULL AND duties.slot = blocks.slot THEN true
-        WHEN blocks.slot IS NOT NULL AND duties.slot != blocks.slot THEN false
-        ELSE NULL
+        WHEN slot_canonical_head.canonical_head_root IS NULL THEN NULL
+        WHEN attestations.head_root = slot_canonical_head.canonical_head_root THEN true
+        ELSE false
     END AS head_correct,
     -- Target correctness
     CASE
@@ -155,9 +172,8 @@ GLOBAL LEFT JOIN attestations ON
 GLOBAL LEFT JOIN gossip_attestations ON
     duties.slot = gossip_attestations.slot
     AND duties.attesting_validator_index = gossip_attestations.attesting_validator_index
-GLOBAL LEFT JOIN blocks ON
-    attestations.head_root = blocks.block_root
-    AND attestations.head_root IS NOT NULL
+GLOBAL LEFT JOIN slot_canonical_head ON
+    duties.slot = slot_canonical_head.slot
 GLOBAL LEFT JOIN target_checkpoints ON
     attestations.target_epoch = target_checkpoints.target_epoch
     AND attestations.target_root IS NOT NULL


### PR DESCRIPTION
## Problem

`fct_attestation_vote_correctness_by_validator.head_correct` is derived by matching the attested block to the block proposed at the attestation's **own** slot:

- vote for the block at the duty slot → `true`
- vote for a block at any other slot → `false`

For a **missed or orphaned** slot there is no canonical block at that slot. The consensus-correct head vote (`get_block_root_at_slot`) is then the most recent canonical block *at or before* the slot — i.e. the previous block. Honest validators attest to it and earn the timely-head reward, but the current logic marks every such attestation `head_correct = false`, because the voted block belongs to an earlier slot.

This penalises the **entire committee** on every missed/orphaned slot, understating head accuracy by roughly the missed-slot rate.

## Fix

Resolve the canonical head for each slot as the most recent slot with `status = 'canonical'` at or before it — a window over `fct_block_proposer` (which already carries a 64-slot lookback buffer) — and compare the attested head against that, matching `get_block_root_at_slot`.

- Votes for the prior block on empty/orphaned slots are now correctly `head_correct = true`.
- Genuine stale-head votes (a canonical block existed at the slot and the validator voted an older one) remain `false`.

Downstream `fct_attestation_vote_correctness_by_validator_{daily,hourly}` inherit the corrected values. Spot-checked against recent mainnet data: previously-flagged head misses on missed/orphaned slots now resolve to correct, while real misses are unaffected.