### PR TITLE
fix(int_beacon_committee_head): fail the task when an interval has incomplete committees

### DIFF
--- a/models/transformations/int_beacon_committee_head.sql
+++ b/models/transformations/int_beacon_committee_head.sql
@@ -47,6 +47,59 @@ votes AS
     GROUP BY
         slot, slot_start_date_time, epoch, epoch_start_date_time,
         committee_index, v_norm
+),
+
+-- Sentries publish a whole epoch's committees as one batch around the epoch
+-- boundary, so the external bound can cover a slot while that batch is still
+-- being ingested. Processing such a slot bakes in a partial committee set
+-- permanently, as incremental intervals are never reprocessed. The committee
+-- count per slot is constant within an epoch, so require every slot in the
+-- interval to have as many committees as its epoch shows anywhere in a
+-- +-2 epoch window, and fail the task otherwise so the scheduler retries
+-- once ingestion has settled.
+--
+-- These scans deliberately read the source table directly (not per_view) and
+-- skip FINAL: committee PRESENCE is unaffected by ReplacingMergeTree version
+-- replacement, and reusing per_view would inline its heavy validators column
+-- a second time.
+expected_per_epoch AS
+(
+    SELECT
+        epoch,
+        uniqExact(committee_index) AS expected_committees
+    FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_beacon_committee" "helpers" "from" }}
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 768 SECOND
+                                   AND fromUnixTimestamp({{ .bounds.end }}) + INTERVAL 768 SECOND
+        AND meta_network_name = '{{ .env.NETWORK }}'
+    GROUP BY epoch
+),
+
+slot_committees AS
+(
+    SELECT
+        slot,
+        any(epoch) AS epoch,
+        uniqExact(committee_index) AS committees
+    FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_beacon_committee" "helpers" "from" }}
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+        AND meta_network_name = '{{ .env.NETWORK }}'
+    GROUP BY slot
+),
+
+-- A slot still mid-ingest can also have ZERO visible rows, which no per-slot
+-- comparison can see, so additionally require every slot on the 12s grid
+-- inside the interval to be present at all. Slot duration is hardcoded the
+-- same way other models hardcode it (e.g. the /12000 propagation buckets).
+gate AS
+(
+    SELECT
+        (
+            SELECT countIf(sc.committees < e.expected_committees)
+            FROM slot_committees AS sc
+            INNER JOIN expected_per_epoch AS e ON sc.epoch = e.epoch
+        ) AS incomplete_slots,
+        toInt64(intDiv({{ .bounds.end }} - {{ .bounds.start }}, 12) + 1)
+            - toInt64((SELECT count() FROM slot_committees)) AS missing_slots
 )
 
 SELECT
@@ -58,6 +111,13 @@ SELECT
     committee_index,
     argMax(v_norm, (votes, toUInt64(cityHash64(v_norm)))) AS validators
 FROM votes
+WHERE (
+    SELECT throwIf(
+        incomplete_slots > 0 OR missing_slots > 0,
+        'int_beacon_committee_head: interval has missing or incomplete slots (ingestion not settled), failing task for retry'
+    )
+    FROM gate
+) = 0
 GROUP BY
     slot,
     slot_start_date_time,


### PR DESCRIPTION
Adds a completeness gate to `int_beacon_committee_head`: every slot in the interval must have as many committees as its epoch shows anywhere in a ±1-epoch window, otherwise `throwIf` fails the insert and the scheduler retries the interval until ingestion has settled. The check derives the expected count from the data itself (committee count is constant within an epoch), so it works for sepolia/hoodi-sized committee counts and historical backfill without hardcoding 64, and it also guards against future ingestion-lag incidents.

Background: sentries publish a whole epoch's committees as one batch at the epoch boundary, so the external bound covers a slot while the batch is still mid-ingest; the forwardfill processed slots against the partially-visible batch and permanently wrote incomplete committee sets (incremental intervals are never reprocessed), and every model that INNER JOINs the committee table silently dropped attestations for validators in the absent committees. On mainnet this cut `int_attestation_attested_head` capture from 100% to ~97.5-99% from 2026-06-03 15:00 UTC: slots with complete committees show 0.001% missing attestations vs ~30% for partial slots (2,679 of 2,680 misses in a 12h sample); the damaged slot 14473697 was processed once, 6s before slot start, with 48/64 committees while raw holds all 64.

Validated against live data: a recent complete interval passes the gate (4,096 rows), the reconstructed 2026-06-03 17:39:41 mid-ingest state throws (the damaged interval would have failed and retried), and sepolia passes with its smaller committee count. Failure/retry semantics confirmed in CBT: asynq MaxRetry(3), archived tasks deleted within ~5s freeing the task ID, scheduler re-enqueues unprocessed intervals each tick, and gap-skipping lets forwardfill continue past a failing interval while backfill keeps retrying it.

Intervals from 2026-06-03 15:00 UTC onward need reprocessing for `int_beacon_committee_head` and downstream (`int_attestation_attested_head`, `fct_attestation_vote_correctness_by_validator` + rollups) once this deploys — raw data is complete, so a re-run fully heals (verified: replaying the model over today's raw data for the damaged slot yields 64/64 committees).