### PR TITLE
fix(skills/optimize-model): isolate artifacts per window + CBT-parity dep accessors

### DIFF
--- a/.claude/skills/optimize-model/SKILL.md
+++ b/.claude/skills/optimize-model/SKILL.md
@@ -83,7 +83,10 @@ SESSION_ID="$SESSION_ID" PREP_OUTPUT="$PREP_OUTPUT" \
   .claude/skills/optimize-model/scripts/run_prepare.sh "$ARGUMENTS"
 ```
 
-- This command generates session-isolated `/tmp` artifacts.
+- This command generates session-isolated `/tmp` artifacts. Artifact names also
+  include the bounds window, so multi-window runs (one prep per window) never
+  overwrite each other's rendered SQL or bench/hash outputs; downstream
+  wrappers resolve paths via the prep manifest (`paths`, `artifact_prefix`).
 - Use `summary`, `period`, `unresolved_fragments`, and `summary.introspection_ok` from `$PREP_OUTPUT`.
 - Confirm `period.bounds_start`/`period.bounds_end` are sane before benchmarking.
 - If unresolved fragments remain, ask targeted follow-up questions and rerun.

--- a/.claude/skills/optimize-model/references/dependency-resolution.md
+++ b/.claude/skills/optimize-model/references/dependency-resolution.md
@@ -23,6 +23,12 @@ Use these rules to convert CBT transformation model templates into a runnable re
   - If template uses `cluster(...)`, resolve dependency table to `<table>_local` (not the Distributed table name).
 - Transformation dependency replacement is direct table access:
   - `` `<transformation_database>`.`<table>` ``
+- Other dep accessors mirror CBT's template engine exactly:
+  - `"database"` => database name only.
+  - `"table"` => bare table name, never suffixed with `_local` (the suffix is
+    applied only inside `helpers.from`). Models doing shard-local pushdowns
+    (e.g. `cluster(..., view(...))`) append `_local` explicitly.
+  - `"cluster"` => cluster name (e.g. `{raw}`); external dependencies only.
 
 ## Common CBT Variables
 For benchmark rendering, substitute these defaults unless user overrides:

--- a/.claude/skills/optimize-model/scripts/prepare_model_analysis.py
+++ b/.claude/skills/optimize-model/scripts/prepare_model_analysis.py
@@ -372,7 +372,10 @@ def main() -> int:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     session_id = args.session_id.strip() or uuid.uuid4().hex[:8]
-    artifact_prefix = f"{args.prefix}.{session_id}"
+    # Include the bounds window in the prefix so repeated preps in one session
+    # (e.g. multi-window benchmarking) never overwrite each other's rendered
+    # SQL; downstream wrappers resolve artifacts via this manifest's paths.
+    artifact_prefix = f"{args.prefix}.{session_id}.{bounds_start}-{bounds_end}"
 
     resolve_json = out_dir / f"{artifact_prefix}.resolve.json"
     schema_json = out_dir / f"{artifact_prefix}.schemas.json"

--- a/.claude/skills/optimize-model/scripts/resolve_model_sql.py
+++ b/.claude/skills/optimize-model/scripts/resolve_model_sql.py
@@ -217,16 +217,23 @@ def replace_dep_helpers(
                 return external_database
             return transformation_database
 
-        # .table => table name only.
+        # .table => bare table name, matching CBT's template engine exactly:
+        # the _local suffix is applied only inside helpers.from, never here.
+        # Models that need the shard-local table (e.g. inside cluster(...,
+        # view(...)) pushdowns) append `_local` explicitly in the template.
         if key1 == "table":
-            if chosen_kind == "external":
-                uses_cluster_function = (
-                    re.search(r"\bcluster\s*\(", external_template, flags=re.IGNORECASE)
-                    is not None
-                )
-                if uses_cluster_function and not table.endswith("_local"):
-                    return f"{table}_local"
             return table
+
+        # .cluster => cluster name from the external access template
+        # (e.g. cluster('{raw}', ...) => {raw}). CBT only exposes this field
+        # on external dependencies, so leave transformation deps unresolved.
+        if key1 == "cluster" and chosen_kind == "external":
+            cluster_match = re.search(
+                r"\bcluster\s*\(\s*'([^']+)'", external_template, flags=re.IGNORECASE
+            )
+            if cluster_match:
+                return cluster_match.group(1)
+            return match.group(0)
 
         # Unknown accessor: leave template unresolved for explicit follow-up.
         return match.group(0)

--- a/.claude/skills/optimize-model/scripts/run_benchmark.sh
+++ b/.claude/skills/optimize-model/scripts/run_benchmark.sh
@@ -35,6 +35,19 @@ print(data['paths']['rendered_sql'])
 PY
 )"
 
+# Window-unique prefix (includes bounds) so benchmarks of different prep
+# windows in one session never overwrite each other.
+ARTIFACT_PREFIX="$(python3 - <<'PY' "$PREP_OUTPUT"
+import json,sys
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
+    data = json.load(f)
+print(data.get('artifact_prefix', ''))
+PY
+)"
+if [ -z "$ARTIFACT_PREFIX" ]; then
+  ARTIFACT_PREFIX="optimize-model.${SESSION_ID}"
+fi
+
 TRANSFORM_ENDPOINT="${TRANSFORM_ENDPOINT:-http://chendpoint-clickhouse-refined.analytics.production.ethpandaops:8123}"
 TRANSFORM_DB="${TRANSFORM_DB:-mainnet}"
 TRANSFORM_USER="${TRANSFORM_USER:-}"
@@ -43,7 +56,7 @@ TRANSFORM_PASS="${TRANSFORM_PASS:-}"
 WARMUP="${WARMUP:-1}"
 RUNS="${RUNS:-3}"
 BENCH_TIMEOUT="${BENCH_TIMEOUT:-300}"
-BENCH_OUTPUT="${BENCH_OUTPUT:-/tmp/optimize-model.${SESSION_ID}.bench.json}"
+BENCH_OUTPUT="${BENCH_OUTPUT:-/tmp/${ARTIFACT_PREFIX}.bench.baseline.json}"
 
 python3 "$SCRIPT_DIR/benchmark_query.py" \
   --query-file "$RENDERED_SQL" \

--- a/.claude/skills/optimize-model/scripts/run_candidate_benchmark.sh
+++ b/.claude/skills/optimize-model/scripts/run_candidate_benchmark.sh
@@ -47,7 +47,20 @@ CANDIDATE_LABEL_RAW="${CANDIDATE_LABEL:-$(basename "$CANDIDATE_SQL" .sql)}"
 WINDOW_LABEL="$(printf '%s' "$WINDOW_LABEL_RAW" | tr -cs 'A-Za-z0-9._-' '_')"
 CANDIDATE_LABEL="$(printf '%s' "$CANDIDATE_LABEL_RAW" | tr -cs 'A-Za-z0-9._-' '_')"
 
-BENCH_OUTPUT="${BENCH_OUTPUT:-/tmp/optimize-model.${SESSION_ID}.bench.${WINDOW_LABEL}.${CANDIDATE_LABEL}.json}"
+# Window-unique prefix (includes bounds) so candidate benchmarks of different
+# prep windows in one session never overwrite each other.
+ARTIFACT_PREFIX="$(python3 - <<'PY' "$PREP_OUTPUT"
+import json,sys
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
+    data = json.load(f)
+print(data.get('artifact_prefix', ''))
+PY
+)"
+if [ -z "$ARTIFACT_PREFIX" ]; then
+  ARTIFACT_PREFIX="optimize-model.${SESSION_ID}"
+fi
+
+BENCH_OUTPUT="${BENCH_OUTPUT:-/tmp/${ARTIFACT_PREFIX}.bench.${WINDOW_LABEL}.${CANDIDATE_LABEL}.json}"
 
 python3 "$SCRIPT_DIR/benchmark_query.py" \
   --query-file "$CANDIDATE_SQL" \

--- a/.claude/skills/optimize-model/scripts/run_hash_check.sh
+++ b/.claude/skills/optimize-model/scripts/run_hash_check.sh
@@ -46,7 +46,21 @@ TRANSFORM_DB="${TRANSFORM_DB:-mainnet}"
 TRANSFORM_USER="${TRANSFORM_USER:-}"
 TRANSFORM_PASS="${TRANSFORM_PASS:-}"
 HASH_TIMEOUT="${HASH_TIMEOUT:-300}"
-HASH_OUTPUT="${HASH_OUTPUT:-/tmp/optimize-model.${SESSION_ID}.hash.json}"
+
+# Window-unique prefix (includes bounds) plus candidate name so hash results
+# of different windows/candidates in one session never overwrite each other.
+ARTIFACT_PREFIX="$(python3 - <<'PY' "$PREP_OUTPUT"
+import json,sys
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
+    data = json.load(f)
+print(data.get('artifact_prefix', ''))
+PY
+)"
+if [ -z "$ARTIFACT_PREFIX" ]; then
+  ARTIFACT_PREFIX="optimize-model.${SESSION_ID}"
+fi
+CANDIDATE_NAME="$(basename "$CANDIDATE_SQL" .sql | tr -cs 'A-Za-z0-9._-' '_')"
+HASH_OUTPUT="${HASH_OUTPUT:-/tmp/${ARTIFACT_PREFIX}.hash.${CANDIDATE_NAME}.json}"
 HASH_MISMATCH_FAIL="${HASH_MISMATCH_FAIL:-0}"
 SERVER_VERSION="${SERVER_VERSION:-$(python3 - <<'PY' "$PREP_OUTPUT"
 import json,sys


### PR DESCRIPTION
## Problem

The optimize-model skill's `/tmp` artifacts are scoped only by session id. Every `run_prepare.sh` invocation within a session writes to the **same** paths:

- `optimize-model.<session>.rendered.sql`
- `optimize-model.<session>.resolve.json` / `.schemas.json`
- `optimize-model.<session>.bench.json` (baseline benchmarks)
- `optimize-model.<session>.hash.json` (hash checks)

The skill's own workflow requires validating candidates across **multiple benchmark windows** (one prep per window), which makes these collisions inevitable:

1. Prep window 1 → `rendered.sql` holds window 1's baseline.
2. Prep window 2 → `rendered.sql` silently replaced with window 2's baseline.
3. Any hash correctness check for a window-1 candidate now compares against the **window-2 baseline** → guaranteed false mismatch (every row differs), or — if the windows happen to produce overlapping output — a misleading match.
4. Baseline benchmark JSONs and hash-check JSONs likewise overwrite each other, so earlier windows' evidence is lost from disk.

False mismatches are especially costly here because the skill treats `hashes_match = false` as a hard rejection gate for otherwise-valid candidates.

Separately, the SQL resolver's dep accessors diverged from CBT's real template engine ([`pkg/models/template.go`](https://github.com/ethpandaops/cbt/blob/master/pkg/models/template.go)):

- `{{ index .dep ... "table" }}` appended `_local` whenever the external access template used `cluster(...)`. CBT never does this — the local suffix is applied **only** inside `helpers.from`. Models that follow CBT semantics and append `_local` explicitly (required for shard-local pushdowns like `cluster(..., view(SELECT ... FROM db.table_local ...))`) rendered as `<table>_local_local` under the skill.
- `{{ index .dep ... "cluster" }}` — a field CBT exposes on external dependencies — was not handled at all, leaving unresolved fragments.

## Changes

**Per-window artifact isolation**
- `prepare_model_analysis.py`: the artifact prefix now includes the bounds window — `<prefix>.<session>.<bounds_start>-<bounds_end>` — so each prep invocation owns unique `rendered.sql`, `resolve.json`, `schemas.json`, and default manifest paths. Re-prepping the same window stays idempotent (same path), and explicit `PREP_OUTPUT`/`BENCH_OUTPUT`/`HASH_OUTPUT` overrides still win.
- `run_benchmark.sh`, `run_candidate_benchmark.sh`, `run_hash_check.sh`: default output paths are now derived from the prep manifest's `artifact_prefix` (with a session-id fallback for old manifests), so baseline benches, candidate benches, and hash results are unique per window. Hash outputs also embed the candidate file name, so checking several candidates against one window no longer overwrites earlier results.

**CBT-parity dep accessors in the resolver**
- `"table"` returns the bare table name, exactly like CBT.
- `"cluster"` is now supported for external dependencies, extracted from the configured external access template (e.g. `cluster('{raw}', ...)` → `{raw}`); transformation deps are left unresolved, matching CBT, which only exposes the field on externals.

**Docs**
- `SKILL.md`: notes that artifacts are isolated per session *and* per bounds window, and that wrappers resolve paths via the prep manifest.
- `references/dependency-resolution.md`: documents the accessor semantics (`database`, `table`, `cluster`) and the explicit-`_local` convention for shard-local pushdown patterns.

## Compatibility

- Wrapper CLIs and env-var overrides are unchanged; all paths surface through the prep manifest (`paths`, `artifact_prefix`) and `BENCH_OUTPUT=`/`HASH_OUTPUT=` echoes, which downstream steps already consume.
- Wrappers remain Bash 3.2+ compatible.
- Manifests produced before this change still work with the updated wrappers via the session-id fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)