### PR TITLE
fix(fct_block_proposer_head): canonical duty backstop + completeness gate

### DIFF
--- a/models/transformations/fct_block_proposer_head.sql
+++ b/models/transformations/fct_block_proposer_head.sql
@@ -15,11 +15,21 @@ tags:
 dependencies:
   - "{{external}}.beacon_api_eth_v1_events_block_gossip"
   - "{{external}}.beacon_api_eth_v1_events_block"
-  - "{{external}}.beacon_api_eth_v1_proposer_duty"
+  - - "{{external}}.beacon_api_eth_v1_proposer_duty"
+    - "{{external}}.canonical_beacon_proposer_duty"
   - "{{external}}.libp2p_gossipsub_beacon_block"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`
+-- Proposer duties are deterministic per epoch (fixed by the RANDAO seed
+-- epochs in advance), so the head-event stream and the canonical table can
+-- never disagree on CONTENT, only on presence. Unioning canonical in makes
+-- it a backstop: at the head its range is empty (it lags finalization) and
+-- it contributes nothing, while in backfilled history it fills slots whose
+-- head-event duty batches were lost to sentry outages. The two duty sources
+-- form an OR-group dependency, so forwardfill is not capped at canonical's
+-- lag. The outer DISTINCT collapses the union back to one row per slot
+-- because the sources' content is identical.
 WITH proposer_duties AS (
     SELECT DISTINCT
         slot,
@@ -28,9 +38,83 @@ WITH proposer_duties AS (
         epoch_start_date_time,
         proposer_validator_index,
         proposer_pubkey
-    FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_proposer_duty" "helpers" "from" }} FINAL
-    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
-        AND meta_network_name = '{{ .env.NETWORK }}'
+    FROM (
+        SELECT
+            slot,
+            slot_start_date_time,
+            epoch,
+            epoch_start_date_time,
+            proposer_validator_index,
+            proposer_pubkey
+        FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_proposer_duty" "helpers" "from" }} FINAL
+        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+            AND meta_network_name = '{{ .env.NETWORK }}'
+        UNION ALL
+        SELECT
+            slot,
+            slot_start_date_time,
+            epoch,
+            epoch_start_date_time,
+            proposer_validator_index,
+            proposer_pubkey
+        FROM {{ index .dep "{{external}}" "canonical_beacon_proposer_duty" "helpers" "from" }} FINAL
+        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+            AND meta_network_name = '{{ .env.NETWORK }}'
+    )
+),
+
+-- Sentries publish a whole epoch's proposer duties as one batch around the
+-- epoch boundary, so the external bound can cover a slot while that batch is
+-- still being ingested. Processing such a slot bakes the gap in permanently:
+-- the slot loses its proposer pubkey, and a missed slot in the gap vanishes
+-- from the table entirely (nothing on either side of the join). Every slot
+-- has exactly one proposer, so completeness here is simply presence: require
+-- every slot on the 12s grid inside the interval to have a duty row in the
+-- union of both sources, and fail the task otherwise so the scheduler
+-- retries once ingestion has settled.
+--
+-- These scans deliberately read the source tables directly (not
+-- proposer_duties) and skip FINAL: duty PRESENCE is unaffected by
+-- ReplacingMergeTree version replacement.
+--
+-- Bounds are not necessarily aligned to the 12s grid (backfill chunks are
+-- arbitrary spans whose length need not be a multiple of 12), so the
+-- expected count cannot be derived from the span length alone: snap the
+-- start bound up to the first on-grid timestamp, using the grid phase
+-- observed from any ingested slot in the interval, then count grid points
+-- up to the end bound. With zero ingested slots the phase is unknowable,
+-- so keep the span-derived over-estimate: the task fails and retries,
+-- the desired outcome for an interval with no duty data at all.
+duty_slots AS (
+    SELECT
+        slot,
+        any(slot_ts) AS slot_ts
+    FROM (
+        SELECT slot, toUnixTimestamp(slot_start_date_time) AS slot_ts
+        FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_proposer_duty" "helpers" "from" }}
+        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+            AND meta_network_name = '{{ .env.NETWORK }}'
+        UNION ALL
+        SELECT slot, toUnixTimestamp(slot_start_date_time) AS slot_ts
+        FROM {{ index .dep "{{external}}" "canonical_beacon_proposer_duty" "helpers" "from" }}
+        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+            AND meta_network_name = '{{ .env.NETWORK }}'
+    )
+    GROUP BY slot
+),
+
+gate AS (
+    SELECT
+        (
+            SELECT
+                if(count() = 0,
+                   toInt64(intDiv({{ .bounds.end }} - {{ .bounds.start }}, 12) + 1),
+                   toInt64(intDiv(
+                       {{ .bounds.end }}
+                           - ({{ .bounds.start }} + ((toInt64(any(slot_ts)) - {{ .bounds.start }}) % 12)),
+                       12) + 1))
+            FROM duty_slots
+        ) - toInt64((SELECT count() FROM duty_slots)) AS missing_slots
 ),
 
 block_gossip AS (
@@ -125,4 +209,18 @@ SELECT
     NULLIF(db.block_root, '') AS block_root
 FROM proposer_duties pd
 GLOBAL FULL OUTER JOIN deduplicated_blocks db ON pd.slot = db.slot
+-- The gate protects against ingestion RACES, which settle within seconds
+-- (emit-to-queryable p999 is under 30s). An interval whose end is more than
+-- an hour old is settled: a slot absent from BOTH the head-event stream and
+-- the canonical table by then is permanently absent, and refusing it forever
+-- would wedge backfill at the first such gap. For settled intervals, bake
+-- what exists.
+WHERE (
+    SELECT throwIf(
+        missing_slots > 0
+            AND fromUnixTimestamp({{ .bounds.end }}) > now() - INTERVAL 1 HOUR,
+        'fct_block_proposer_head: interval has slots with no proposer duty (ingestion not settled), failing task for retry'
+    )
+    FROM gate
+) = 0
 SETTINGS join_use_nulls = 1;

--- a/tests/mainnet/models/fct_block_proposer_head.yaml
+++ b/tests/mainnet/models/fct_block_proposer_head.yaml
@@ -10,6 +10,9 @@ external_data:
     beacon_api_eth_v1_proposer_duty:
         url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_block_proposer_head_beacon_api_eth_v1_proposer_duty.parquet
         network_column: meta_network_name
+    canonical_beacon_proposer_duty:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/canonical_beacon_proposer_duty.parquet
+        network_column: meta_network_name
     libp2p_gossipsub_beacon_block:
         url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_block_proposer_head_libp2p_gossipsub_beacon_block.parquet
         network_column: meta_network_name


### PR DESCRIPTION
Applies the `int_beacon_committee_head` recipe (#266) to proposer duties.

**Backstop:** `canonical_beacon_proposer_duty` is unioned into the duty source as an OR-group dependency. Duties are deterministic per epoch, so the two sources can never disagree on content, only presence — canonical fills head-stream gaps in backfilled history while contributing nothing at the head (OR-group bounds are a union, so forwardfill is not capped at canonical's lag).

**Completeness gate:** every slot on the 12s grid must have a duty row in the union of both sources (grid-phase-aware count from #264, 1h settle-age grace from #266). This model previously had no gate, leaving it exposed to the same epoch-batch ingestion race that hit committees.

**Why:** the May 2026 sentry outage left 195 slots (14326624–14327615) with no head-stream duty rows — baked into production with an empty `proposer_pubkey`. A missed slot inside such a gap vanishes from the table entirely (nothing on either side of the FULL OUTER JOIN), silently breaking missed-slot detection.

Validated against production via panda before pushing: gate reports exactly 195 missing on the May window head-only vs 0 with the union; 12/12 grid phases clean on an off-grid 997s window; full rendered query over the gap window yields 1020/1020 grid slots, 0 missing pubkeys (vs 195 baked today), missed slots preserved, no duplicate rows from the union. Local harness 10/10.