### PR TITLE
feat(models): canonical backstops so attestation correctness backfills pre-event

### DIFF
--- a/models/transformations/fct_attestation_vote_correctness_by_validator.sql
+++ b/models/transformations/fct_attestation_vote_correctness_by_validator.sql
@@ -14,8 +14,12 @@ tags:
   - vote_correctness
   - validator_performance
 dependencies:
-  - "{{transformation}}.int_attestation_attested_canonical"
-  - "{{transformation}}.int_attestation_attested_head"
+  # OR group: head supplies gossip first-seen timing (LEFT JOINed, NULL when
+  # absent) and only exists from the event era; canonical reaches genesis and is
+  # the primary attestation source. Either satisfies coverage, so the model
+  # backfills to genesis with NULL gossip-timing columns pre-event.
+  - - "{{transformation}}.int_attestation_attested_head"
+    - "{{transformation}}.int_attestation_attested_canonical"
   - "{{transformation}}.fct_block_proposer"
   - "{{external}}.canonical_beacon_committee"
   - "{{external}}.canonical_beacon_block"

--- a/models/transformations/fct_block_proposer.sql
+++ b/models/transformations/fct_block_proposer.sql
@@ -13,8 +13,12 @@ tags:
   - proposer
   - canonical
 dependencies:
-  - "{{transformation}}.int_block_proposer_canonical"
-  - "{{transformation}}.fct_block_proposer_head"
+  # OR group: head gives orphaned-block status but only exists from the
+  # gossip/event era; canonical reaches genesis and is the primary source (the
+  # SQL drives FROM it). Either satisfies coverage, so the model backfills to
+  # genesis (status falls back to canonical/missed when head is absent).
+  - - "{{transformation}}.fct_block_proposer_head"
+    - "{{transformation}}.int_block_proposer_canonical"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`


### PR DESCRIPTION
OR-group the event-stream dependencies of `fct_block_proposer` (`fct_block_proposer_head` → OR `int_block_proposer_canonical`) and `fct_attestation_vote_correctness_by_validator` (`int_attestation_attested_head` → OR `int_attestation_attested_canonical`) with their canonical equivalents, matching the existing `int_beacon_committee_head`/`fct_block_proposer_head` backstops. These models are floored at 2025 only because the event data — which is supplementary and already LEFT-JOINed (orphaned-block status, gossip first-seen timing) — doesn't exist earlier; canonical reaches genesis, so relaxing coverage lets the whole canonical chain backfill the full history (`correctness_by_validator_canonical` and `inclusion_delay` fully correct; `vote_correctness` with NULL gossip-timing pre-event), while `int_attestation_first_seen_aggregate` is left unchanged as it has no canonical equivalent.

SQL is unchanged — this only relaxes dependency-coverage scheduling; pulling the history down is a follow-up coverage-reset op once deployed.