### PR TITLE
DO NOT MERGE: CI harness probe (no-op fct_block_proposer)

### DIFF
--- a/models/transformations/fct_block_proposer.sql
+++ b/models/transformations/fct_block_proposer.sql
@@ -60,3 +60,5 @@ SELECT
     END as status
 FROM canonical c
 GLOBAL LEFT JOIN head_blocks h ON c.slot = h.slot
+
+-- ci probe: no-op comment to mark fct_block_proposer impacted (testing harness, not a real change)


### PR DESCRIPTION
Throwaway probe: a comment-only change to fct_block_proposer to confirm whether the test-mainnet pre-clone failure on #271 is caused by the OR-group change or just by making fct_block_proposer impacted (stale cbt_template). Will close once CI reports.