### PR TITLE
fix(testing): run migrations against the target database

### DIFF
--- a/internal/testing/database.go
+++ b/internal/testing/database.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -245,7 +246,7 @@ func (m *DatabaseManager) CreateCBTTemplate(ctx context.Context, migrationDir st
 	logCtx.Info("running migrations")
 
 	migrationStart := time.Now()
-	if err := m.runMigrations(ctx, m.cbtConn, templateDB, migrationDir); err != nil {
+	if err := m.runMigrations(ctx, m.cbtConnStr, templateDB, migrationDir); err != nil {
 		return fmt.Errorf("running CBT template migrations: %w", err)
 	}
 
@@ -490,7 +491,7 @@ func (m *DatabaseManager) CreateTestDatabase(
 	logCtx.Info("running migrations")
 
 	migrationStart := time.Now()
-	if err := m.runMigrations(ctx, m.cbtConn, dbName, migrationDir); err != nil {
+	if err := m.runMigrations(ctx, m.cbtConnStr, dbName, migrationDir); err != nil {
 		_ = m.DropDatabase(ctx, dbName)
 		return "", fmt.Errorf("running xatu-cbt migrations: %w", err)
 	}
@@ -1246,9 +1247,39 @@ func loadVerbatimMigrationFS(dir string) (fs.FS, error) {
 	return filesystem, nil
 }
 
+// openDatabaseConn opens a ClickHouse connection whose session database is set
+// to dbName, by overriding the path of the base connection string. Migrations
+// run with unqualified DDL, so they must execute against the target database.
+func openDatabaseConn(connStr, dbName string) (*sql.DB, error) {
+	dsn, err := scopedDSN(connStr, dbName)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := sql.Open("clickhouse", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("opening clickhouse connection: %w", err)
+	}
+
+	return conn, nil
+}
+
+// scopedDSN returns connStr with its path overridden to dbName, so a connection
+// opened from it uses dbName as the session database.
+func scopedDSN(connStr, dbName string) (string, error) {
+	parsed, err := url.Parse(connStr)
+	if err != nil {
+		return "", fmt.Errorf("parsing connection string: %w", err)
+	}
+
+	parsed.Path = "/" + dbName
+
+	return parsed.String(), nil
+}
+
 func (m *DatabaseManager) runMigrations(
 	ctx context.Context,
-	conn *sql.DB,
+	connStr,
 	dbName,
 	migrationDir string,
 ) error {
@@ -1269,6 +1300,16 @@ func (m *DatabaseManager) runMigrations(
 	if err != nil {
 		return fmt.Errorf("creating source driver: %w", err)
 	}
+
+	// Scope the migration connection to the target database. Migrations use
+	// unqualified table names and Distributed(currentDatabase(), ...), so they
+	// must run with dbName as the session database; otherwise the tables are
+	// created in the connection's default database rather than dbName.
+	conn, err := openDatabaseConn(connStr, dbName)
+	if err != nil {
+		return fmt.Errorf("opening migration connection for %s: %w", dbName, err)
+	}
+	defer func() { _ = conn.Close() }()
 
 	migrationsTableName := fmt.Sprintf("schema_migrations_%s", dbName)
 	dbDriver, err := clickhouse.WithInstance(conn, &clickhouse.Config{

--- a/internal/testing/database.go
+++ b/internal/testing/database.go
@@ -1181,7 +1181,15 @@ func (m *DatabaseManager) runXatuSetMigrations(ctx context.Context, set config.X
 		return fmt.Errorf("creating source driver: %w", err)
 	}
 
-	dbDriver, err := clickhouse.WithInstance(m.xatuConn, &clickhouse.Config{
+	// Scope the migration connection to the target database so unqualified DDL
+	// lands in set.Database rather than the connection's default database.
+	conn, err := openDatabaseConn(m.xatuConnStr, set.Database)
+	if err != nil {
+		return fmt.Errorf("opening migration connection for %s: %w", set.Database, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	dbDriver, err := clickhouse.WithInstance(conn, &clickhouse.Config{
 		DatabaseName:          set.Database,
 		MigrationsTable:       fmt.Sprintf("%s%s", config.SchemaMigrationsPrefix, set.Name),
 		MultiStatementEnabled: true,

--- a/internal/testing/database_test.go
+++ b/internal/testing/database_test.go
@@ -27,3 +27,37 @@ func TestModifyCreateTableForClone_CrossDatabaseRenameDoesNotDoublePrefix(t *tes
 	require.Contains(t, modified, "'observoor_cpu_utilization_local'")
 	require.NotContains(t, modified, "observoor_observoor_cpu_utilization")
 }
+
+func TestScopedDSN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		connStr string
+		dbName  string
+		want    string
+	}{
+		{
+			name:    "adds database path to bare dsn",
+			connStr: "clickhouse://default:supersecret@localhost:9000",
+			dbName:  "cbt_template",
+			want:    "clickhouse://default:supersecret@localhost:9000/cbt_template",
+		},
+		{
+			name:    "overrides an existing database path",
+			connStr: "clickhouse://default:supersecret@localhost:9000/default",
+			dbName:  "mainnet",
+			want:    "clickhouse://default:supersecret@localhost:9000/mainnet",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := scopedDSN(tt.connStr, tt.dbName)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Since migrations were made database-agnostic in #269 they use unqualified table names and `Distributed(currentDatabase(), ...)`, so they must run with the target database as the session database — but `runMigrations` executed them on the shared `cbtConn` whose DSN has no database, so the session database was `default` and every model table was created in `default` instead of `cbt_template` (and the per-network databases), leaving `cbt_template` missing tables and per-test clones failing intermittently with "Table doesn't exist". This opens a connection scoped to the target database (DSN path `/dbName`) for each migration run; verified locally on the 2-shard cluster that tables now land in `cbt_template` and the previously-failing clones/models pass.