### PR TITLE
feat(attestation): union canonical attestations as backfill backstop in int_attestation_attested_head

### DIFF
--- a/migrations/084_attestation_attested_head_nullable_propagation.down.sql
+++ b/migrations/084_attestation_attested_head_nullable_propagation.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE int_attestation_attested_head ON CLUSTER '{cluster}'
+    MODIFY COLUMN `propagation_distance` UInt32 COMMENT 'The distance from the slot when the attestation was propagated. 0 means the attestation was propagated within the same slot as its duty was assigned, 1 means the attestation was propagated within the next slot, etc.' CODEC(DoubleDelta, ZSTD(1));
+
+ALTER TABLE int_attestation_attested_head_local ON CLUSTER '{cluster}'
+    MODIFY COLUMN `propagation_distance` UInt32 COMMENT 'The distance from the slot when the attestation was propagated. 0 means the attestation was propagated within the same slot as its duty was assigned, 1 means the attestation was propagated within the next slot, etc.' CODEC(DoubleDelta, ZSTD(1));

--- a/migrations/084_attestation_attested_head_nullable_propagation.up.sql
+++ b/migrations/084_attestation_attested_head_nullable_propagation.up.sql
@@ -1,0 +1,9 @@
+-- Canonical-sourced attesters have no gossip-propagation timing, so
+-- int_attestation_attested_head.propagation_distance must allow NULL for them
+-- (matching fct_attestation_correctness_by_validator_head, which already
+-- declares this column Nullable(UInt32)).
+ALTER TABLE int_attestation_attested_head_local ON CLUSTER '{cluster}'
+    MODIFY COLUMN `propagation_distance` Nullable(UInt32) COMMENT 'The distance from the slot when the attestation was propagated. 0 means the attestation was propagated within the same slot as its duty was assigned, 1 means the attestation was propagated within the next slot, etc. NULL for canonical-sourced attesters, which carry no gossip-propagation timing.' CODEC(DoubleDelta, ZSTD(1));
+
+ALTER TABLE int_attestation_attested_head ON CLUSTER '{cluster}'
+    MODIFY COLUMN `propagation_distance` Nullable(UInt32) COMMENT 'The distance from the slot when the attestation was propagated. 0 means the attestation was propagated within the same slot as its duty was assigned, 1 means the attestation was propagated within the next slot, etc. NULL for canonical-sourced attesters, which carry no gossip-propagation timing.' CODEC(DoubleDelta, ZSTD(1));

--- a/models/transformations/int_attestation_attested_head.sql
+++ b/models/transformations/int_attestation_attested_head.sql
@@ -12,8 +12,9 @@ tags:
   - attestation
   - head
 dependencies:
-  - "{{external}}.beacon_api_eth_v1_events_attestation"
-  - "{{external}}.libp2p_gossipsub_beacon_attestation"
+  - - "{{external}}.beacon_api_eth_v1_events_attestation"
+    - "{{external}}.libp2p_gossipsub_beacon_attestation"
+    - "{{external}}.canonical_beacon_elaborated_attestation"
   - "{{transformation}}.int_beacon_committee_head"
 ---
 INSERT INTO
@@ -30,7 +31,18 @@ WITH validator_indices AS (
     WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
 ),
 
--- Get the events for the attestations that were captured
+-- Get the events for the attestations that were captured. The two real-time
+-- sources (beacon API event stream + libp2p gossip) only ever see the subset
+-- of attesters whose attestations propagated to a sentry before the slot was
+-- processed (~35-66% at the head). canonical_beacon_elaborated_attestation is
+-- unioned in as a third source so that backfilled/finalized history is sourced
+-- from the chain-included attestation set (~99% participation) instead. The
+-- three sources form an OR-group dependency, so forwardfill is not capped at
+-- canonical's lag: at the head canonical's range is empty and it contributes
+-- nothing, leaving the real-time sources to serve the live tip, while in
+-- backfilled history it provides the complete attester set. Canonical rows
+-- carry no gossip-propagation timing, so their propagation_distance is NULL
+-- (head rows keep their measured propagation; min() ignores the NULLs).
 combined_events AS (
     SELECT
         slot,
@@ -74,6 +86,42 @@ combined_events AS (
         AND meta_network_name = '{{ .env.NETWORK }}'
         AND aggregation_bits = ''
         AND attesting_validator_index IS NOT NULL
+    GROUP BY slot, slot_start_date_time, epoch, epoch_start_date_time, beacon_block_root, source_epoch, source_epoch_start_date_time, source_root, target_epoch, target_epoch_start_date_time, target_root, attesting_validator_index
+
+    UNION ALL
+
+    SELECT
+        slot,
+        slot_start_date_time,
+        epoch,
+        epoch_start_date_time,
+        beacon_block_root,
+        source_epoch,
+        source_epoch_start_date_time,
+        source_root,
+        target_epoch,
+        target_epoch_start_date_time,
+        target_root,
+        attesting_validator_index,
+        CAST(NULL AS Nullable(UInt32)) AS propagation_distance
+    FROM (
+        SELECT
+            slot,
+            slot_start_date_time,
+            epoch,
+            epoch_start_date_time,
+            beacon_block_root,
+            source_epoch,
+            source_epoch_start_date_time,
+            source_root,
+            target_epoch,
+            target_epoch_start_date_time,
+            target_root,
+            arrayJoin(validators) AS attesting_validator_index
+        FROM {{ index .dep "{{external}}" "canonical_beacon_elaborated_attestation" "helpers" "from" }} FINAL
+        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+            AND meta_network_name = '{{ .env.NETWORK }}'
+    )
     GROUP BY slot, slot_start_date_time, epoch, epoch_start_date_time, beacon_block_root, source_epoch, source_epoch_start_date_time, source_root, target_epoch, target_epoch_start_date_time, target_root, attesting_validator_index
 ),
 

--- a/tests/mainnet/models/int_attestation_attested_head.yaml
+++ b/tests/mainnet/models/int_attestation_attested_head.yaml
@@ -10,6 +10,9 @@ external_data:
     libp2p_gossipsub_beacon_attestation:
         url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/int_attestation_attested_head_libp2p_gossipsub_beacon_attestation.parquet
         network_column: meta_network_name
+    canonical_beacon_elaborated_attestation:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/canonical_beacon_elaborated_attestation.parquet
+        network_column: meta_network_name
 assertions:
     - name: Row count should be greater than zero
       sql: |


### PR DESCRIPTION
Unions `canonical_beacon_elaborated_attestation` as a third OR-group source in `int_attestation_attested_head`: at chain head canonical is empty so the live tip stays real-time event-stream data, while backfilled/finalized history uses the complete chain-included attester set (~99%) instead of the ~35-66% the event stream captures live, mirroring the canonical-backstop OR-group pattern from #266/#267. This fixes the per-slot attestations view (and the `_head` correctness models) mislabeling canonically-attesting validators as "offline" — e.g. mainnet slot 13769099: event-stream 13,263 vs canonical 29,890 of 30,091 committee; output stays one row per (slot, validator) since head and canonical agree on roots.