### PR TITLE
feat(attestation): add fct_attestation_correctness canonical-preferred merge

### DIFF
--- a/migrations/085_fct_attestation_correctness.down.sql
+++ b/migrations/085_fct_attestation_correctness.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS fct_attestation_correctness ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS fct_attestation_correctness_local ON CLUSTER '{cluster}';

--- a/migrations/085_fct_attestation_correctness.up.sql
+++ b/migrations/085_fct_attestation_correctness.up.sql
@@ -1,0 +1,34 @@
+CREATE TABLE fct_attestation_correctness_local on cluster '{cluster}' (
+    `updated_date_time` DateTime COMMENT 'Timestamp when the record was last updated' CODEC(DoubleDelta, ZSTD(1)),
+    `slot` UInt32 COMMENT 'The slot number' CODEC(DoubleDelta, ZSTD(1)),
+    `slot_start_date_time` DateTime COMMENT 'The wall clock time when the slot started' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch` UInt32 COMMENT 'The epoch number containing the slot' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch_start_date_time` DateTime COMMENT 'The wall clock time when the epoch started' CODEC(DoubleDelta, ZSTD(1)),
+    `block_root` Nullable(String) COMMENT 'The beacon block root hash' CODEC(ZSTD(1)),
+    `votes_max` UInt32 COMMENT 'The maximum number of scheduled votes for the block' CODEC(ZSTD(1)),
+    `votes_head` Nullable(UInt32) COMMENT 'The number of votes for the block proposed in the current slot' CODEC(ZSTD(1)),
+    `votes_other` Nullable(UInt32) COMMENT 'The number of votes for any blocks proposed in previous slots' CODEC(ZSTD(1))
+) ENGINE = ReplicatedReplacingMergeTree(
+    '/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}',
+    '{replica}',
+    `updated_date_time`
+) PARTITION BY toStartOfMonth(slot_start_date_time)
+ORDER BY
+    (`slot_start_date_time`)
+SETTINGS
+    deduplicate_merge_projection_mode = 'rebuild'
+COMMENT 'Attestation correctness of a block, preferring finalized canonical data and falling back to real-time head data for slots not yet finalized. Forks in the chain may cause multiple block roots for the same slot to be present';
+
+CREATE TABLE fct_attestation_correctness ON CLUSTER '{cluster}' AS fct_attestation_correctness_local ENGINE = Distributed(
+    '{cluster}',
+    currentDatabase(),
+    fct_attestation_correctness_local,
+    cityHash64(`slot_start_date_time`)
+);
+
+ALTER TABLE fct_attestation_correctness_local ON CLUSTER '{cluster}'
+ADD PROJECTION p_by_slot
+(
+    SELECT *
+    ORDER BY (`slot`)
+);

--- a/models/transformations/fct_attestation_correctness.sql
+++ b/models/transformations/fct_attestation_correctness.sql
@@ -1,0 +1,62 @@
+---
+table: fct_attestation_correctness
+type: incremental
+interval:
+  type: slot
+  max: 384
+schedules:
+  forwardfill: "@every 30s"
+  backfill: "@every 1m"
+tags:
+  - slot
+  - attestation
+  - canonical
+dependencies:
+  - "{{transformation}}.fct_attestation_correctness_canonical"
+  - "{{transformation}}.fct_attestation_correctness_head"
+---
+INSERT INTO
+  `{{ .self.database }}`.`{{ .self.table }}`
+WITH canonical AS (
+    SELECT
+        slot,
+        slot_start_date_time,
+        epoch,
+        epoch_start_date_time,
+        block_root,
+        votes_max,
+        votes_head,
+        votes_other
+    FROM {{ index .dep "{{transformation}}" "fct_attestation_correctness_canonical" "helpers" "from" }} FINAL
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+),
+
+head AS (
+    SELECT
+        slot,
+        slot_start_date_time,
+        epoch,
+        epoch_start_date_time,
+        block_root,
+        votes_max,
+        votes_head,
+        votes_other
+    FROM {{ index .dep "{{transformation}}" "fct_attestation_correctness_head" "helpers" "from" }} FINAL
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+)
+
+SELECT
+    fromUnixTimestamp({{ .task.start }}) as updated_date_time,
+    CASE WHEN c.slot_start_date_time IS NOT NULL AND c.slot_start_date_time != toDateTime(0) THEN c.slot ELSE h.slot END as slot,
+    CASE WHEN c.slot_start_date_time IS NOT NULL AND c.slot_start_date_time != toDateTime(0) THEN c.slot_start_date_time ELSE h.slot_start_date_time END as slot_start_date_time,
+    CASE WHEN c.slot_start_date_time IS NOT NULL AND c.slot_start_date_time != toDateTime(0) THEN c.epoch ELSE h.epoch END as epoch,
+    CASE WHEN c.slot_start_date_time IS NOT NULL AND c.slot_start_date_time != toDateTime(0) THEN c.epoch_start_date_time ELSE h.epoch_start_date_time END as epoch_start_date_time,
+    CASE WHEN c.slot_start_date_time IS NOT NULL AND c.slot_start_date_time != toDateTime(0) THEN c.block_root ELSE h.block_root END as block_root,
+    CASE WHEN c.slot_start_date_time IS NOT NULL AND c.slot_start_date_time != toDateTime(0) THEN c.votes_max ELSE h.votes_max END as votes_max,
+    CASE WHEN c.slot_start_date_time IS NOT NULL AND c.slot_start_date_time != toDateTime(0) THEN c.votes_head ELSE h.votes_head END as votes_head,
+    CASE WHEN c.slot_start_date_time IS NOT NULL AND c.slot_start_date_time != toDateTime(0) THEN c.votes_other ELSE h.votes_other END as votes_other
+FROM canonical c
+GLOBAL FULL OUTER JOIN head h
+    ON c.slot_start_date_time = h.slot_start_date_time
+    AND cityHash64(coalesce(c.block_root, '')) = cityHash64(coalesce(h.block_root, ''))
+SETTINGS join_use_nulls = 1

--- a/tests/mainnet/models/fct_attestation_correctness.yaml
+++ b/tests/mainnet/models/fct_attestation_correctness.yaml
@@ -1,0 +1,128 @@
+model: fct_attestation_correctness
+network: mainnet
+external_data:
+    beacon_api_eth_v1_beacon_committee:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_head_beacon_api_eth_v1_beacon_committee.parquet
+        network_column: meta_network_name
+    beacon_api_eth_v1_events_attestation:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_head_beacon_api_eth_v1_events_attestation.parquet
+        network_column: meta_network_name
+    beacon_api_eth_v1_events_block:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_head_beacon_api_eth_v1_events_block.parquet
+        network_column: meta_network_name
+    beacon_api_eth_v1_events_block_gossip:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_head_beacon_api_eth_v1_events_block_gossip.parquet
+        network_column: meta_network_name
+    beacon_api_eth_v1_proposer_duty:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_head_beacon_api_eth_v1_proposer_duty.parquet
+        network_column: meta_network_name
+    libp2p_gossipsub_beacon_attestation:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_head_libp2p_gossipsub_beacon_attestation.parquet
+        network_column: meta_network_name
+    libp2p_gossipsub_beacon_block:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_head_libp2p_gossipsub_beacon_block.parquet
+        network_column: meta_network_name
+assertions:
+    - name: Row count should be greater than zero
+      sql: |
+        SELECT COUNT(*) AS row_count FROM fct_attestation_correctness FINAL
+      assertions:
+        - type: greater_than
+          column: row_count
+          value: 0
+    - name: No null slot start date time
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness FINAL
+        WHERE slot_start_date_time IS NULL
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: slot_start_date_time should not be the zero timestamp
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness FINAL
+        WHERE slot_start_date_time = toDateTime('1970-01-01 00:00:00')
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No rows with negative or zero slot values
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness FINAL
+        WHERE slot < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No rows with negative epoch values
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness FINAL
+        WHERE epoch < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Epoch should equal floor of slot divided by 32
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness FINAL
+        WHERE epoch != intDiv(slot, 32)
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No rows with empty block_root
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness FINAL
+        WHERE block_root = ''
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: votes_max should never be negative
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness FINAL
+        WHERE votes_max < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: votes_head when present should be greater than zero
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness FINAL
+        WHERE votes_head IS NOT NULL AND votes_head <= 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: votes_head should not exceed votes_max when both are present
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness FINAL
+        WHERE votes_head IS NOT NULL AND votes_max > 0 AND votes_head > votes_max
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: votes_head plus votes_other should not exceed votes_max
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness FINAL
+        WHERE votes_head IS NOT NULL
+          AND votes_other IS NOT NULL
+          AND votes_max > 0
+          AND (votes_head + votes_other) > votes_max
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Each slot and block_root combination should be unique
+      sql: |
+        SELECT COUNT(*) AS duplicate_count
+        FROM (
+          SELECT slot, block_root, COUNT(*) AS cnt
+          FROM fct_attestation_correctness FINAL
+          GROUP BY slot, block_root
+          HAVING cnt > 1
+        )
+      assertions:
+        - type: equals
+          column: duplicate_count
+          value: 0


### PR DESCRIPTION
Adds an unsuffixed `fct_attestation_correctness` table that merges the two existing per-slot correctness tables (`fct_attestation_correctness_canonical` and `fct_attestation_correctness_head`), following the canonical-merge convention: prefer the settled canonical data (votes_head is the finalized ~99% truth) and fall back to real-time head data for slots not yet finalized. The model AND-depends on both sources and does a GLOBAL FULL OUTER JOIN on (slot_start_date_time, block_root), NULL-normalizing block_root so missed-slot rows still join; each output column is chosen with a CASE that prefers canonical. Migration 085 CREATEs the new \_local (ReplicatedReplacingMergeTree) + Distributed table mirroring the \_head/\_canonical DDL (including the p_by_slot projection) and is database-agnostic (unqualified names, currentDatabase(), {database} ZK macro). The mainnet test reuses the \_head fixtures since the merge runs the whole chain from the same leaves. The schemas are identical between \_head and \_canonical so no timing-column reconciliation is needed. Downstream rollups still read the \_head/\_canonical tables; this table is purely additive. Pending serial infra steps (cannot run in parallel CBT infra): make proto for the new table, generate overlapping head+canonical fixtures, and run the test harness.