### PR TITLE
feat(attestation): add int_attestation_attested canonical-preferred merge

### DIFF
--- a/migrations/084_int_attestation_attested.down.sql
+++ b/migrations/084_int_attestation_attested.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS int_attestation_attested ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS int_attestation_attested_local ON CLUSTER '{cluster}';

--- a/migrations/084_int_attestation_attested.up.sql
+++ b/migrations/084_int_attestation_attested.up.sql
@@ -1,0 +1,33 @@
+CREATE TABLE int_attestation_attested_local on cluster '{cluster}' (
+    `updated_date_time` DateTime COMMENT 'Timestamp when the record was last updated' CODEC(DoubleDelta, ZSTD(1)),
+    `slot` UInt32 COMMENT 'The slot number' CODEC(DoubleDelta, ZSTD(1)),
+    `slot_start_date_time` DateTime COMMENT 'The wall clock time when the slot started' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch` UInt32 COMMENT 'The epoch number containing the slot' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch_start_date_time` DateTime COMMENT 'The wall clock time when the epoch started' CODEC(DoubleDelta, ZSTD(1)),
+    `source_epoch` UInt32 COMMENT 'The source epoch number in the attestation group',
+    `source_epoch_start_date_time` DateTime COMMENT 'The wall clock time when the source epoch started',
+    `source_root` FixedString(66) COMMENT 'The source beacon block root hash in the attestation group',
+    `target_epoch` UInt32 COMMENT 'The target epoch number in the attestation group',
+    `target_epoch_start_date_time` DateTime COMMENT 'The wall clock time when the target epoch started',
+    `target_root` FixedString(66) COMMENT 'The target beacon block root hash in the attestation group',
+    `block_root` String COMMENT 'The beacon block root hash' CODEC(ZSTD(1)),
+    `attesting_validator_index` UInt32 COMMENT 'The index of the validator attesting' CODEC(ZSTD(1)),
+    `inclusion_distance` Nullable(UInt32) COMMENT 'The distance from the slot when the attestation was included on-chain. Taken from the canonical variant; null when only the head variant recorded the attestation.' CODEC(ZSTD(1)),
+    `propagation_distance` Nullable(UInt32) COMMENT 'The distance from the slot when the attestation was propagated over gossip. 0 means the attestation was propagated within the same slot as its duty was assigned, 1 means the next slot, etc. Taken from the head variant; null when only the canonical variant recorded the attestation.' CODEC(DoubleDelta, ZSTD(1)),
+) ENGINE = ReplicatedReplacingMergeTree(
+    '/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}',
+    '{replica}',
+    `updated_date_time`
+) PARTITION BY toStartOfMonth(slot_start_date_time)
+ORDER BY
+    (`slot_start_date_time`, `block_root`, `attesting_validator_index`)
+SETTINGS
+    deduplicate_merge_projection_mode = 'rebuild'
+COMMENT 'Canonical-preferred merge of attested head and canonical attestations. Prefers finalized canonical values per validator and slot, falling back to real-time head.';
+
+CREATE TABLE int_attestation_attested ON CLUSTER '{cluster}' AS int_attestation_attested_local ENGINE = Distributed(
+    '{cluster}',
+    currentDatabase(),
+    int_attestation_attested_local,
+    cityHash64(`slot_start_date_time`, `block_root`, `attesting_validator_index`)
+);

--- a/models/transformations/int_attestation_attested.sql
+++ b/models/transformations/int_attestation_attested.sql
@@ -1,0 +1,82 @@
+---
+table: int_attestation_attested
+type: incremental
+interval:
+  type: slot
+  max: 384
+schedules:
+  forwardfill: "@every 30s"
+  backfill: "@every 1m"
+tags:
+  - slot
+  - attestation
+  - canonical
+dependencies:
+  - "{{transformation}}.int_attestation_attested_canonical"
+  - "{{transformation}}.int_attestation_attested_head"
+---
+INSERT INTO
+  `{{ .self.database }}`.`{{ .self.table }}`
+-- Canonical-preferred merge of the finalized (canonical) and real-time (head)
+-- attestation variants. Canonical values win per (slot, attesting_validator_index,
+-- block_root); head-only rows survive so orphaned-target votes the canonical chain
+-- never recorded are still represented.
+WITH canonical AS (
+    SELECT
+        slot,
+        slot_start_date_time,
+        epoch,
+        epoch_start_date_time,
+        source_epoch,
+        source_epoch_start_date_time,
+        source_root,
+        target_epoch,
+        target_epoch_start_date_time,
+        target_root,
+        block_root,
+        attesting_validator_index,
+        inclusion_distance
+    FROM {{ index .dep "{{transformation}}" "int_attestation_attested_canonical" "helpers" "from" }} FINAL
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+),
+
+head AS (
+    SELECT
+        slot,
+        slot_start_date_time,
+        epoch,
+        epoch_start_date_time,
+        source_epoch,
+        source_epoch_start_date_time,
+        source_root,
+        target_epoch,
+        target_epoch_start_date_time,
+        target_root,
+        block_root,
+        attesting_validator_index,
+        propagation_distance
+    FROM {{ index .dep "{{transformation}}" "int_attestation_attested_head" "helpers" "from" }} FINAL
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+)
+
+SELECT
+    fromUnixTimestamp({{ .task.start }}) as updated_date_time,
+    COALESCE(c.slot, h.slot) AS slot,
+    CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.slot_start_date_time ELSE h.slot_start_date_time END AS slot_start_date_time,
+    CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.epoch ELSE h.epoch END AS epoch,
+    CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.epoch_start_date_time ELSE h.epoch_start_date_time END AS epoch_start_date_time,
+    CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.source_epoch ELSE h.source_epoch END AS source_epoch,
+    CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.source_epoch_start_date_time ELSE h.source_epoch_start_date_time END AS source_epoch_start_date_time,
+    CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.source_root ELSE h.source_root END AS source_root,
+    CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.target_epoch ELSE h.target_epoch END AS target_epoch,
+    CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.target_epoch_start_date_time ELSE h.target_epoch_start_date_time END AS target_epoch_start_date_time,
+    CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.target_root ELSE h.target_root END AS target_root,
+    COALESCE(c.block_root, h.block_root) AS block_root,
+    COALESCE(c.attesting_validator_index, h.attesting_validator_index) AS attesting_validator_index,
+    CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.inclusion_distance ELSE NULL END AS inclusion_distance,
+    CASE WHEN h.attesting_validator_index IS NOT NULL THEN h.propagation_distance ELSE NULL END AS propagation_distance
+FROM canonical c
+GLOBAL FULL OUTER JOIN head h
+    ON c.slot = h.slot
+    AND c.attesting_validator_index = h.attesting_validator_index
+    AND c.block_root = h.block_root

--- a/tests/mainnet/models/int_attestation_attested.yaml
+++ b/tests/mainnet/models/int_attestation_attested.yaml
@@ -1,0 +1,110 @@
+model: int_attestation_attested
+network: mainnet
+external_data:
+    beacon_api_eth_v1_beacon_committee:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/int_attestation_attested_head_beacon_api_eth_v1_beacon_committee.parquet
+        network_column: meta_network_name
+    beacon_api_eth_v1_events_attestation:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/int_attestation_attested_head_beacon_api_eth_v1_events_attestation.parquet
+        network_column: meta_network_name
+    libp2p_gossipsub_beacon_attestation:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/int_attestation_attested_head_libp2p_gossipsub_beacon_attestation.parquet
+        network_column: meta_network_name
+    canonical_beacon_committee:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/int_attestation_attested_canonical_canonical_beacon_committee.parquet
+        network_column: meta_network_name
+    canonical_beacon_elaborated_attestation:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/int_attestation_attested_canonical_canonical_beacon_elaborated_attestation.parquet
+        network_column: meta_network_name
+assertions:
+    - name: Row count should be greater than zero
+      sql: |
+        SELECT COUNT(*) AS row_count FROM int_attestation_attested FINAL
+      assertions:
+        - type: greater_than
+          column: row_count
+          value: 0
+    - name: No null attesting validator indices
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM int_attestation_attested FINAL
+        WHERE attesting_validator_index IS NULL
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No negative attesting validator indices
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM int_attestation_attested FINAL
+        WHERE attesting_validator_index < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No null slot start date time
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM int_attestation_attested FINAL
+        WHERE slot_start_date_time IS NULL OR slot_start_date_time = toDateTime('1970-01-01 00:00:00')
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No null block root
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM int_attestation_attested FINAL
+        WHERE block_root IS NULL OR block_root = ''
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Epoch should equal floor of slot divided by 32
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM int_attestation_attested FINAL
+        WHERE epoch != intDiv(slot, 32)
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Target epoch should be greater than or equal to source epoch
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM int_attestation_attested FINAL
+        WHERE target_epoch < source_epoch
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No negative inclusion distance when present
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM int_attestation_attested FINAL
+        WHERE inclusion_distance IS NOT NULL AND inclusion_distance < 1
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No negative propagation distance when present
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM int_attestation_attested FINAL
+        WHERE propagation_distance IS NOT NULL AND propagation_distance < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Every row carries at least one timing column
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM int_attestation_attested FINAL
+        WHERE inclusion_distance IS NULL AND propagation_distance IS NULL
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No duplicate rows per slot validator and block root
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM (
+          SELECT slot, attesting_validator_index, block_root, COUNT(*) AS dupes
+          FROM int_attestation_attested FINAL
+          GROUP BY slot, attesting_validator_index, block_root
+          HAVING dupes > 1
+        )
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0


### PR DESCRIPTION
Adds the unsuffixed `int_attestation_attested` table following the canonical-merge convention: an AND-dependency merge over `int_attestation_attested_canonical` and `int_attestation_attested_head` that prefers finalized canonical values per (slot, attesting_validator_index, block_root) and falls back to real-time head. This is the real non-deterministic target (head captures ~35% vs canonical ~99%), so settled canonical truth wins while head-only rows (e.g. orphaned-target votes the canonical chain never recorded) still survive via a GLOBAL FULL OUTER JOIN. The table carries both timing columns as Nullable(UInt32) from the start (no ALTER): `inclusion_distance` from canonical and `propagation_distance` from head, each null when only the other variant recorded the attestation. It runs on the canonical schedule (forwardfill @30s / backfill @1m) since the AND-deps gate on the slower canonical parent. Migration 084 CREATEs the `_local` + Distributed table (database-agnostic: unqualified names, currentDatabase() in Distributed, {database} macro in the ZK path). `int_attestation_attested_head` stays pure real-time head and is untouched. This supersedes the WIP canonical bolt-on in #276, which should be closed. The new merge feeds the upcoming fct_attestation_correctness / fct_attestation_correctness_by_validator tables; the existing fct_attestation_vote_correctness_by_validator already AND-depends on both source variants and is unaffected.

Pending infra steps (serial, shared CBT infra): run `make proto` to generate the new table's bindings; generate overlapping head+canonical test fixtures so the merge exercises both branches of the FULL OUTER JOIN; run the test harness for int_attestation_attested.