### PR TITLE
feat(attestation): add fct_attestation_liveness_by_entity off the canonical-preferred merge

### DIFF
--- a/migrations/087_fct_attestation_liveness_by_entity.down.sql
+++ b/migrations/087_fct_attestation_liveness_by_entity.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS fct_attestation_liveness_by_entity ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS fct_attestation_liveness_by_entity_local ON CLUSTER '{cluster}';

--- a/migrations/087_fct_attestation_liveness_by_entity.up.sql
+++ b/migrations/087_fct_attestation_liveness_by_entity.up.sql
@@ -1,0 +1,33 @@
+CREATE TABLE fct_attestation_liveness_by_entity_local on cluster '{cluster}' (
+    `updated_date_time` DateTime COMMENT 'Timestamp when the record was last updated' CODEC(DoubleDelta, ZSTD(1)),
+    `slot` UInt32 COMMENT 'The slot number' CODEC(DoubleDelta, ZSTD(1)),
+    `slot_start_date_time` DateTime COMMENT 'The wall clock time when the slot started' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch` UInt32 COMMENT 'The epoch number containing the slot' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch_start_date_time` DateTime COMMENT 'The wall clock time when the epoch started' CODEC(DoubleDelta, ZSTD(1)),
+    `entity` String COMMENT 'The entity (staking provider) associated with the validators, unknown if not mapped' CODEC(ZSTD(1)),
+    `attestation_count` UInt32 COMMENT 'Number of attestations for this entity' CODEC(ZSTD(1)),
+    `missed_count` UInt32 COMMENT 'Number of missed attestations for this entity' CODEC(ZSTD(1))
+) ENGINE = ReplicatedReplacingMergeTree(
+    '/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}',
+    '{replica}',
+    `updated_date_time`
+) PARTITION BY toStartOfMonth(slot_start_date_time)
+ORDER BY
+    (`slot_start_date_time`, `entity`)
+SETTINGS
+    deduplicate_merge_projection_mode = 'rebuild'
+COMMENT 'Attestation liveness aggregated by entity, preferring settled canonical participation over the real-time head view. One row per (slot, entity) with counts for both attested and missed attestations.';
+
+CREATE TABLE fct_attestation_liveness_by_entity ON CLUSTER '{cluster}' AS fct_attestation_liveness_by_entity_local ENGINE = Distributed(
+    '{cluster}',
+    currentDatabase(),
+    fct_attestation_liveness_by_entity_local,
+    cityHash64(`slot`)
+);
+
+ALTER TABLE fct_attestation_liveness_by_entity_local ON CLUSTER '{cluster}'
+ADD PROJECTION p_by_slot
+(
+    SELECT *
+    ORDER BY (`slot`)
+);

--- a/models/transformations/fct_attestation_liveness_by_entity.sql
+++ b/models/transformations/fct_attestation_liveness_by_entity.sql
@@ -1,0 +1,45 @@
+---
+table: fct_attestation_liveness_by_entity
+type: incremental
+interval:
+  type: slot
+  max: 50000
+schedules:
+  forwardfill: "@every 30s"
+  backfill: "@every 30s"
+tags:
+  - slot
+  - attestation
+  - entity
+dependencies:
+  - "{{transformation}}.fct_attestation_correctness_by_validator"
+  - "{{transformation}}.dim_node"
+---
+INSERT INTO
+  `{{ .self.database }}`.`{{ .self.table }}`
+WITH attestations_with_entity AS (
+    SELECT
+        acv.slot,
+        acv.slot_start_date_time,
+        acv.epoch,
+        acv.epoch_start_date_time,
+        COALESCE(dn.source, 'unknown') AS entity,
+        acv.block_root
+    FROM {{ index .dep "{{transformation}}" "fct_attestation_correctness_by_validator" "helpers" "from" }} AS acv FINAL
+    GLOBAL LEFT JOIN {{ index .dep "{{transformation}}" "dim_node" "helpers" "from" }} AS dn FINAL
+        ON acv.attesting_validator_index = dn.validator_index
+    WHERE acv.slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+)
+
+SELECT
+    fromUnixTimestamp({{ .task.start }}) as updated_date_time,
+    slot,
+    slot_start_date_time,
+    epoch,
+    epoch_start_date_time,
+    entity,
+    countIf(block_root IS NOT NULL) as attestation_count,
+    countIf(block_root IS NULL) as missed_count
+FROM attestations_with_entity
+GROUP BY slot, slot_start_date_time, epoch, epoch_start_date_time, entity
+SETTINGS join_use_nulls = 1

--- a/tests/mainnet/models/fct_attestation_liveness_by_entity.yaml
+++ b/tests/mainnet/models/fct_attestation_liveness_by_entity.yaml
@@ -1,0 +1,112 @@
+model: fct_attestation_liveness_by_entity
+network: mainnet
+external_data:
+    beacon_api_eth_v1_beacon_committee:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_liveness_by_entity_head_beacon_api_eth_v1_beacon_committee.parquet
+        network_column: meta_network_name
+    beacon_api_eth_v1_events_attestation:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_liveness_by_entity_head_beacon_api_eth_v1_events_attestation.parquet
+        network_column: meta_network_name
+    beacon_api_eth_v1_events_block:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_liveness_by_entity_head_beacon_api_eth_v1_events_block.parquet
+        network_column: meta_network_name
+    beacon_api_eth_v1_events_block_gossip:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_liveness_by_entity_head_beacon_api_eth_v1_events_block_gossip.parquet
+        network_column: meta_network_name
+    beacon_api_eth_v1_proposer_duty:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_liveness_by_entity_head_beacon_api_eth_v1_proposer_duty.parquet
+        network_column: meta_network_name
+    ethseer_validator_entity:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_liveness_by_entity_head_ethseer_validator_entity.parquet
+        network_column: meta_network_name
+    libp2p_gossipsub_beacon_attestation:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_liveness_by_entity_head_libp2p_gossipsub_beacon_attestation.parquet
+        network_column: meta_network_name
+    libp2p_gossipsub_beacon_block:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_liveness_by_entity_head_libp2p_gossipsub_beacon_block.parquet
+        network_column: meta_network_name
+assertions:
+    - name: Row count should be greater than zero
+      sql: |
+        SELECT COUNT(*) AS row_count FROM fct_attestation_liveness_by_entity FINAL
+      assertions:
+        - type: greater_than
+          column: row_count
+          value: 0
+    - name: No null entity values
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_liveness_by_entity FINAL
+        WHERE entity IS NULL OR entity = ''
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No negative attestation_count values
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_liveness_by_entity FINAL
+        WHERE attestation_count < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No negative missed_count values
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_liveness_by_entity FINAL
+        WHERE missed_count < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Total of attestation_count and missed_count should be greater than zero per row
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_liveness_by_entity FINAL
+        WHERE (attestation_count + missed_count) <= 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Slot values should be non-negative
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_liveness_by_entity FINAL
+        WHERE slot < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Epoch values should be non-negative
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_liveness_by_entity FINAL
+        WHERE epoch < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: slot_start_date_time should not be null
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_liveness_by_entity FINAL
+        WHERE slot_start_date_time IS NULL
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Each slot-entity combination should be unique
+      sql: |
+        SELECT COUNT(*) AS duplicate_count
+        FROM (
+          SELECT slot, entity, COUNT(*) AS cnt
+          FROM fct_attestation_liveness_by_entity FINAL
+          GROUP BY slot, entity
+          HAVING cnt > 1
+        )
+      assertions:
+        - type: equals
+          column: duplicate_count
+          value: 0
+    - name: updated_date_time should not be null
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_liveness_by_entity FINAL
+        WHERE updated_date_time IS NULL
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0


### PR DESCRIPTION
Adds a new unsuffixed `fct_attestation_liveness_by_entity` transformation that re-points the existing head-only liveness-by-entity aggregation onto the new unsuffixed `fct_attestation_correctness_by_validator` parent, which prefers settled canonical participation over the real-time head view. There is no `_canonical` liveness model to merge, so this is a structural re-point rather than a CASE/COALESCE prefer-canonical merge: the SQL is cloned verbatim from `fct_attestation_liveness_by_entity_head` with its only dependency swapped from `fct_attestation_correctness_by_validator_head` to the unsuffixed parent, inheriting canonical preference transitively. Output schema (entity String, attestation_count UInt32, missed_count UInt32) and the migration are exact mirrors of the `_head` table (023); migration 087 creates `fct_attestation_liveness_by_entity(_local + Distributed)` database-agnostic. Cadence drops to the canonical forwardfill (@every 30s) since the parent now lags canonical finalization. Counts now reflect the settled ~99% canonical participation instead of head's ~35% real-time view, which is the point. The `_head` model is untouched and keeps serving the real-time view. Stacked on the `fct_attestation_correctness_by_validator` PR (hard parent dep). Pending serial infra steps (cannot run in parallel CBT infra): make proto for the new table, generate overlapping head+canonical test fixtures, and run the test harness.