### PR TITLE
feat(attestation): add fct_attestation_correctness_by_validator canonical-preferred merge

### DIFF
--- a/migrations/086_fct_attestation_correctness_by_validator.down.sql
+++ b/migrations/086_fct_attestation_correctness_by_validator.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS fct_attestation_correctness_by_validator ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS fct_attestation_correctness_by_validator_local ON CLUSTER '{cluster}';

--- a/migrations/086_fct_attestation_correctness_by_validator.up.sql
+++ b/migrations/086_fct_attestation_correctness_by_validator.up.sql
@@ -1,0 +1,29 @@
+CREATE TABLE fct_attestation_correctness_by_validator_local on cluster '{cluster}' (
+    `updated_date_time` DateTime COMMENT 'Timestamp when the record was last updated' CODEC(DoubleDelta, ZSTD(1)),
+    `slot` UInt32 COMMENT 'The slot number' CODEC(DoubleDelta, ZSTD(1)),
+    `slot_start_date_time` DateTime COMMENT 'The wall clock time when the slot started' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch` UInt32 COMMENT 'The epoch number containing the slot' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch_start_date_time` DateTime COMMENT 'The wall clock time when the epoch started' CODEC(DoubleDelta, ZSTD(1)),
+    `attesting_validator_index` UInt32 COMMENT 'The index of the validator attesting' CODEC(ZSTD(1)),
+    `block_root` Nullable(String) COMMENT 'The beacon block root hash that was attested, null means the attestation was missed' CODEC(ZSTD(1)),
+    `slot_distance` Nullable(UInt32) COMMENT 'The distance from the slot to the attested block. If the attested block is the same as the slot, the distance is 0, if the attested block is the previous slot, the distance is 1, etc. If null, the attestation was missed, the block was orphaned and never seen by a sentry or the block was more than 64 slots ago' CODEC(DoubleDelta, ZSTD(1)),
+    `propagation_distance` Nullable(UInt32) COMMENT 'The distance from the slot when the attestation was propagated, sourced from head. 0 means the attestation was propagated within the same slot as its duty was assigned, 1 means the attestation was propagated within the next slot, etc. Null when only the canonical source is present' CODEC(DoubleDelta, ZSTD(1)),
+    `inclusion_distance` Nullable(UInt32) COMMENT 'The distance from the slot when the attestation was included in a block, sourced from canonical. Null when only the head source is present' CODEC(DoubleDelta, ZSTD(1)),
+    `status` LowCardinality(Nullable(String)) COMMENT 'Sourced from canonical: "canonical", "orphaned", "missed" or "unknown" (validator attested but block data not available). Null when only the head source is present (not yet finalized)',
+) ENGINE = ReplicatedReplacingMergeTree(
+    '/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}',
+    '{replica}',
+    `updated_date_time`
+) PARTITION BY toStartOfMonth(slot_start_date_time)
+ORDER BY
+    (`slot_start_date_time`, `attesting_validator_index`)
+SETTINGS
+    deduplicate_merge_projection_mode = 'rebuild'
+COMMENT 'Attestation correctness by validator, canonical-preferred merge of the canonical and head sources';
+
+CREATE TABLE fct_attestation_correctness_by_validator ON CLUSTER '{cluster}' AS fct_attestation_correctness_by_validator_local ENGINE = Distributed(
+    '{cluster}',
+    currentDatabase(),
+    fct_attestation_correctness_by_validator_local,
+    cityHash64(`slot_start_date_time`, `attesting_validator_index`)
+);

--- a/models/transformations/fct_attestation_correctness_by_validator.sql
+++ b/models/transformations/fct_attestation_correctness_by_validator.sql
@@ -1,0 +1,68 @@
+---
+table: fct_attestation_correctness_by_validator
+type: incremental
+interval:
+  type: slot
+  max: 384
+schedules:
+  forwardfill: "@every 30s"
+  backfill: "@every 1m"
+tags:
+  - slot
+  - attestation
+  - canonical
+dependencies:
+  - "{{transformation}}.fct_attestation_correctness_by_validator_canonical"
+  - "{{transformation}}.fct_attestation_correctness_by_validator_head"
+---
+INSERT INTO
+  `{{ .self.database }}`.`{{ .self.table }}`
+WITH canonical AS (
+    SELECT
+        slot,
+        slot_start_date_time,
+        epoch,
+        epoch_start_date_time,
+        attesting_validator_index,
+        block_root,
+        slot_distance,
+        inclusion_distance,
+        `status`
+    FROM {{ index .dep "{{transformation}}" "fct_attestation_correctness_by_validator_canonical" "helpers" "from" }} FINAL
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+),
+
+head AS (
+    SELECT
+        slot,
+        slot_start_date_time,
+        epoch,
+        epoch_start_date_time,
+        attesting_validator_index,
+        block_root,
+        slot_distance,
+        propagation_distance
+    FROM {{ index .dep "{{transformation}}" "fct_attestation_correctness_by_validator_head" "helpers" "from" }} FINAL
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+)
+
+-- Canonical-preferred merge: one row per (slot_start_date_time, attesting_validator_index).
+-- Prefer the canonical (finalized) value when present, otherwise fall back to the head value.
+-- propagation_distance is only available from head; inclusion_distance and status only from canonical.
+SELECT
+  fromUnixTimestamp({{ .task.start }}) AS updated_date_time,
+  CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.slot ELSE h.slot END AS slot,
+  CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.slot_start_date_time ELSE h.slot_start_date_time END AS slot_start_date_time,
+  CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.epoch ELSE h.epoch END AS epoch,
+  CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.epoch_start_date_time ELSE h.epoch_start_date_time END AS epoch_start_date_time,
+  CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.attesting_validator_index ELSE h.attesting_validator_index END AS attesting_validator_index,
+  CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.block_root ELSE h.block_root END AS block_root,
+  CASE WHEN c.attesting_validator_index IS NOT NULL THEN c.slot_distance ELSE h.slot_distance END AS slot_distance,
+  h.propagation_distance AS propagation_distance,
+  c.inclusion_distance AS inclusion_distance,
+  c.`status` AS `status`
+FROM canonical c
+GLOBAL FULL OUTER JOIN head h ON
+    c.slot_start_date_time = h.slot_start_date_time
+    AND c.attesting_validator_index = h.attesting_validator_index
+SETTINGS join_use_nulls = 1

--- a/tests/mainnet/models/fct_attestation_correctness_by_validator.yaml
+++ b/tests/mainnet/models/fct_attestation_correctness_by_validator.yaml
@@ -1,0 +1,136 @@
+model: fct_attestation_correctness_by_validator
+network: mainnet
+external_data:
+    beacon_api_eth_v1_beacon_committee:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_by_validator_beacon_api_eth_v1_beacon_committee.parquet
+        network_column: meta_network_name
+    beacon_api_eth_v1_events_attestation:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_by_validator_beacon_api_eth_v1_events_attestation.parquet
+        network_column: meta_network_name
+    beacon_api_eth_v1_events_block:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_by_validator_beacon_api_eth_v1_events_block.parquet
+        network_column: meta_network_name
+    beacon_api_eth_v1_events_block_gossip:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_by_validator_beacon_api_eth_v1_events_block_gossip.parquet
+        network_column: meta_network_name
+    beacon_api_eth_v1_proposer_duty:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_by_validator_beacon_api_eth_v1_proposer_duty.parquet
+        network_column: meta_network_name
+    libp2p_gossipsub_beacon_attestation:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_by_validator_libp2p_gossipsub_beacon_attestation.parquet
+        network_column: meta_network_name
+    libp2p_gossipsub_beacon_block:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_by_validator_libp2p_gossipsub_beacon_block.parquet
+        network_column: meta_network_name
+    canonical_beacon_block:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_by_validator_canonical_beacon_block.parquet
+        network_column: meta_network_name
+    canonical_beacon_committee:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_by_validator_canonical_beacon_committee.parquet
+        network_column: meta_network_name
+    canonical_beacon_elaborated_attestation:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_by_validator_canonical_beacon_elaborated_attestation.parquet
+        network_column: meta_network_name
+    canonical_beacon_proposer_duty:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_attestation_correctness_by_validator_canonical_beacon_proposer_duty.parquet
+        network_column: meta_network_name
+assertions:
+    - name: Row count should be greater than zero
+      sql: |
+        SELECT COUNT(*) AS row_count FROM fct_attestation_correctness_by_validator FINAL
+      assertions:
+        - type: greater_than
+          column: row_count
+          value: 0
+    - name: No negative slot values
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness_by_validator FINAL
+        WHERE slot < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No negative epoch values
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness_by_validator FINAL
+        WHERE epoch < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No null attesting_validator_index values
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness_by_validator FINAL
+        WHERE attesting_validator_index IS NULL
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No negative attesting_validator_index values
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness_by_validator FINAL
+        WHERE attesting_validator_index < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No null slot_start_date_time values
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness_by_validator FINAL
+        WHERE slot_start_date_time IS NULL
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: No null updated_date_time values
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness_by_validator FINAL
+        WHERE updated_date_time IS NULL
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Slot distance should be non-negative when present
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness_by_validator FINAL
+        WHERE slot_distance IS NOT NULL AND slot_distance < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Propagation distance should be non-negative when present
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness_by_validator FINAL
+        WHERE propagation_distance IS NOT NULL AND propagation_distance < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Inclusion distance should be non-negative when present
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness_by_validator FINAL
+        WHERE inclusion_distance IS NOT NULL AND inclusion_distance < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Status should be a known value when present
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_attestation_correctness_by_validator FINAL
+        WHERE status IS NOT NULL AND status NOT IN ('canonical', 'orphaned', 'missed', 'unknown')
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Each validator should appear at most once per slot
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM (
+          SELECT slot, attesting_validator_index, COUNT(*) AS cnt
+          FROM fct_attestation_correctness_by_validator FINAL
+          GROUP BY slot, attesting_validator_index
+          HAVING cnt > 1
+        )
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0


### PR DESCRIPTION
Adds the unsuffixed `fct_attestation_correctness_by_validator` table as a canonical-preferred merge of the existing `_canonical` and `_head` per-validator sources, following the unsuffixed-merge convention (cf. `fct_block_proposer`). The model AND-depends on both sources, GLOBAL FULL OUTER JOINs them on (slot_start_date_time, attesting_validator_index), and prefers the canonical (settled/finalized) value per key while falling back to head where canonical is not yet present. The output schema is the union of both: `block_root`/`slot_distance` prefer canonical, `propagation_distance` comes from head (null when only canonical), and `inclusion_distance`/`status` come from canonical (null when only head, i.e. not-yet-finalized). Migration 086 creates the `_local` ReplicatedReplacingMergeTree + Distributed table (ORDER BY (slot_start_date_time, attesting_validator_index), cityHash64 shard key) with all timing columns Nullable from the start and `status` as LowCardinality(Nullable(String)) — no ALTERs. This becomes the canonical-preferred source the upcoming `fct_attestation_liveness_by_entity` will read; `fct_attestation_liveness_by_entity_head` keeps reading the `_head` variant. boltOnRevert=none, so no `_head` model changes. Pending infra steps (run serially afterward, cannot run in parallel CBT infra): `make proto` for the new table, generate overlapping head+canonical test fixtures, and run the test harness.