### PR TITLE
feat(committee): add int_beacon_committee merge and un-bolt int_beacon_committee_head back to pure beacon_api

### DIFF
--- a/migrations/088_int_beacon_committee.down.sql
+++ b/migrations/088_int_beacon_committee.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS int_beacon_committee ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS int_beacon_committee_local ON CLUSTER '{cluster}';

--- a/migrations/088_int_beacon_committee.up.sql
+++ b/migrations/088_int_beacon_committee.up.sql
@@ -1,0 +1,25 @@
+CREATE TABLE int_beacon_committee_local on cluster '{cluster}' (
+    `updated_date_time` DateTime COMMENT 'Timestamp when the record was last updated' CODEC(DoubleDelta, ZSTD(1)),
+    `slot` UInt32 COMMENT 'The slot number' CODEC(DoubleDelta, ZSTD(1)),
+    `slot_start_date_time` DateTime COMMENT 'The wall clock time when the slot started' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch` UInt32 COMMENT 'The epoch number containing the slot' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch_start_date_time` DateTime COMMENT 'The wall clock time when the epoch started' CODEC(DoubleDelta, ZSTD(1)),
+    `committee_index` LowCardinality(String) COMMENT 'The committee index in the beacon API committee payload',
+    `validators` Array(UInt32) COMMENT 'The validator indices in the beacon API committee payload' CODEC(ZSTD(1))
+) ENGINE = ReplicatedReplacingMergeTree(
+    '/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}',
+    '{replica}',
+    `updated_date_time`
+) PARTITION BY toStartOfMonth(slot_start_date_time)
+ORDER BY
+    (`slot_start_date_time`, `committee_index`)
+SETTINGS
+    deduplicate_merge_projection_mode = 'rebuild'
+COMMENT 'Beacon committee, canonical-preferred merge of the head-event stream and the canonical table';
+
+CREATE TABLE int_beacon_committee ON CLUSTER '{cluster}' AS int_beacon_committee_local ENGINE = Distributed(
+    '{cluster}',
+    currentDatabase(),
+    int_beacon_committee_local,
+    cityHash64(`slot_start_date_time`, `committee_index`)
+);

--- a/models/transformations/int_beacon_committee.sql
+++ b/models/transformations/int_beacon_committee.sql
@@ -1,0 +1,161 @@
+---
+table: int_beacon_committee
+type: incremental
+interval:
+  type: slot
+  max: 384
+schedules:
+  forwardfill: "@every 30s"
+  backfill: "@every 1m"
+tags:
+  - slot
+  - beacon
+  - committee
+  - canonical
+dependencies:
+  - "{{external}}.beacon_api_eth_v1_beacon_committee"
+  - "{{external}}.canonical_beacon_committee"
+---
+INSERT INTO
+  `{{ .self.database }}`.`{{ .self.table }}`
+WITH
+-- Committee assignment is deterministic per epoch (fixed by the RANDAO seed
+-- epochs in advance), so the head-event stream and the canonical table can
+-- never disagree on CONTENT, only on presence. This is the settled merge:
+-- it AND-depends on canonical, so it lags finalization, and where both
+-- sources have a (slot, committee_index) it prefers the canonical validator
+-- set. The head-event stream backfills committees whose canonical batch has
+-- not landed yet within the dependency's available range.
+head AS
+(
+    SELECT
+        slot,
+        slot_start_date_time,
+        epoch,
+        epoch_start_date_time,
+        committee_index,
+        arraySort(arrayDistinct(validators)) AS v_norm
+    FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_beacon_committee" "helpers" "from" }} FINAL
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+        AND meta_network_name = '{{ .env.NETWORK }}'
+    GROUP BY
+        slot, slot_start_date_time, epoch, epoch_start_date_time, committee_index, validators
+),
+
+canonical AS
+(
+    SELECT
+        slot,
+        slot_start_date_time,
+        epoch,
+        epoch_start_date_time,
+        committee_index,
+        arraySort(arrayDistinct(validators)) AS v_norm
+    FROM {{ index .dep "{{external}}" "canonical_beacon_committee" "helpers" "from" }} FINAL
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+        AND meta_network_name = '{{ .env.NETWORK }}'
+    GROUP BY
+        slot, slot_start_date_time, epoch, epoch_start_date_time, committee_index, validators
+),
+
+merged AS
+(
+    SELECT
+        COALESCE(c.slot, h.slot) AS slot,
+        COALESCE(c.slot_start_date_time, h.slot_start_date_time) AS slot_start_date_time,
+        COALESCE(c.epoch, h.epoch) AS epoch,
+        COALESCE(c.epoch_start_date_time, h.epoch_start_date_time) AS epoch_start_date_time,
+        COALESCE(c.committee_index, h.committee_index) AS committee_index,
+        CASE
+            WHEN length(c.v_norm) > 0 THEN c.v_norm
+            ELSE h.v_norm
+        END AS validators
+    FROM canonical c
+    GLOBAL FULL OUTER JOIN head h
+        ON c.slot = h.slot AND c.committee_index = h.committee_index
+),
+
+-- Sentries publish a whole epoch's committees as one batch around the epoch
+-- boundary, so the external bound can cover a slot while that batch is still
+-- being ingested. Require every slot in the interval to have as many
+-- committees as its epoch shows anywhere in a +-2 epoch window, and fail the
+-- task otherwise so the scheduler retries once ingestion has settled.
+-- Presence is the union of both sources.
+presence_window AS
+(
+    SELECT slot, epoch, committee_index, slot_start_date_time
+    FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_beacon_committee" "helpers" "from" }}
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 768 SECOND
+                                   AND fromUnixTimestamp({{ .bounds.end }}) + INTERVAL 768 SECOND
+        AND meta_network_name = '{{ .env.NETWORK }}'
+    UNION ALL
+    SELECT slot, epoch, committee_index, slot_start_date_time
+    FROM {{ index .dep "{{external}}" "canonical_beacon_committee" "helpers" "from" }}
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 768 SECOND
+                                   AND fromUnixTimestamp({{ .bounds.end }}) + INTERVAL 768 SECOND
+        AND meta_network_name = '{{ .env.NETWORK }}'
+),
+
+expected_per_epoch AS
+(
+    SELECT
+        epoch,
+        uniqExact(committee_index) AS expected_committees
+    FROM presence_window
+    GROUP BY epoch
+),
+
+slot_committees AS
+(
+    SELECT
+        slot,
+        any(epoch) AS epoch,
+        any(toUnixTimestamp(slot_start_date_time)) AS slot_ts,
+        uniqExact(committee_index) AS committees
+    FROM presence_window
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+    GROUP BY slot
+),
+
+gate AS
+(
+    SELECT
+        (
+            SELECT countIf(sc.committees < e.expected_committees)
+            FROM slot_committees AS sc
+            INNER JOIN expected_per_epoch AS e ON sc.epoch = e.epoch
+        ) AS incomplete_slots,
+        (
+            SELECT
+                if(count() = 0,
+                   toInt64(intDiv({{ .bounds.end }} - {{ .bounds.start }}, 12) + 1),
+                   toInt64(intDiv(
+                       {{ .bounds.end }}
+                           - ({{ .bounds.start }} + ((toInt64(any(slot_ts)) - {{ .bounds.start }}) % 12)),
+                       12) + 1))
+            FROM slot_committees
+        ) - toInt64((SELECT count() FROM slot_committees)) AS missing_slots
+)
+
+SELECT
+    fromUnixTimestamp({{ .task.start }}) as updated_date_time,
+    slot,
+    slot_start_date_time,
+    epoch,
+    epoch_start_date_time,
+    committee_index,
+    validators
+FROM merged
+-- The gate protects against ingestion RACES, which settle within seconds. An
+-- interval whose end is more than an hour old is settled: anything absent from
+-- BOTH the head-event stream and the canonical table by then is permanently
+-- absent, and refusing it forever would stall backfill at the first such gap.
+WHERE (
+    SELECT throwIf(
+        (incomplete_slots > 0 OR missing_slots > 0)
+            AND fromUnixTimestamp({{ .bounds.end }}) > now() - INTERVAL 1 HOUR,
+        'int_beacon_committee: interval has missing or incomplete slots (ingestion not settled), failing task for retry'
+    )
+    FROM gate
+) = 0
+ORDER BY slot, committee_index;

--- a/tests/mainnet/models/int_beacon_committee.yaml
+++ b/tests/mainnet/models/int_beacon_committee.yaml
@@ -1,0 +1,80 @@
+model: int_beacon_committee
+network: mainnet
+external_data:
+    beacon_api_eth_v1_beacon_committee:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/int_beacon_committee_head_beacon_api_eth_v1_beacon_committee.parquet
+        network_column: meta_network_name
+    canonical_beacon_committee:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/canonical_beacon_committee.parquet
+        network_column: meta_network_name
+assertions:
+    - name: Row count should be greater than zero
+      sql: |
+        SELECT COUNT(*) AS count FROM int_beacon_committee FINAL
+      assertions:
+        - type: greater_than
+          column: count
+          value: 0
+    - name: Slot should be non-negative
+      sql: |
+        SELECT MIN(slot) AS min_slot FROM int_beacon_committee FINAL
+      assertions:
+        - type: greater_than_or_equal
+          column: min_slot
+          value: 0
+    - name: Epoch should be non-negative
+      sql: |
+        SELECT MIN(epoch) AS min_epoch FROM int_beacon_committee FINAL
+      assertions:
+        - type: greater_than_or_equal
+          column: min_epoch
+          value: 0
+    - name: Committee index should be non-negative
+      sql: |
+        SELECT MIN(toUInt32(committee_index)) AS min_committee_index FROM int_beacon_committee FINAL
+      assertions:
+        - type: greater_than_or_equal
+          column: min_committee_index
+          value: 0
+    - name: Validators array should not be empty
+      sql: |
+        SELECT COUNT(*) AS empty_validators FROM int_beacon_committee FINAL WHERE length(validators) = 0
+      assertions:
+        - type: equals
+          column: empty_validators
+          value: 0
+    - name: Slot start date time should not be null
+      sql: |
+        SELECT COUNT(*) AS null_count FROM int_beacon_committee FINAL WHERE slot_start_date_time IS NULL
+      assertions:
+        - type: equals
+          column: null_count
+          value: 0
+    - name: Epoch start date time should not be null
+      sql: |
+        SELECT COUNT(*) AS null_count FROM int_beacon_committee FINAL WHERE epoch_start_date_time IS NULL
+      assertions:
+        - type: equals
+          column: null_count
+          value: 0
+    - name: Slot and committee index combination should be unique
+      sql: |
+        SELECT COUNT(*) - COUNT(DISTINCT (slot, committee_index)) AS duplicate_count FROM int_beacon_committee FINAL
+      assertions:
+        - type: equals
+          column: duplicate_count
+          value: 0
+    - name: Epoch should be consistent with slot (slot / 32)
+      sql: |
+        SELECT COUNT(*) AS inconsistent_epochs FROM int_beacon_committee FINAL WHERE epoch != intDiv(slot, 32)
+      assertions:
+        - type: equals
+          column: inconsistent_epochs
+          value: 0
+    - name: Updated date time should not be null
+      sql: |
+        SELECT COUNT(*) AS null_count FROM int_beacon_committee FINAL WHERE updated_date_time IS NULL
+      assertions:
+        - type: equals
+          column: null_count
+          value: 0


### PR DESCRIPTION
Adds the unsuffixed `int_beacon_committee` as the settled, canonical-preferred merge of `beacon_api_eth_v1_beacon_committee` (real-time head stream) and `canonical_beacon_committee`, following the unsuffixed-merge convention: it AND-depends on both sources so it lags finalization, prefers the canonical validator set per (slot, committee_index), and falls back to the head set where the canonical batch has not landed yet. Output columns mirror `int_beacon_committee_head` exactly and the +-2 epoch presence gate is carried over to reject mid-ingest intervals. Migration 088 creates `int_beacon_committee(_local)` mirroring 017's `int_beacon_committee_head_local` schema (database-agnostic: unqualified names, `currentDatabase()` in the Distributed engine, `{database}` macro in the ZK path). Note on the title: despite the refactor goal of un-bolting, `int_beacon_committee_head` is deliberately LEFT bolted to its canonical OR-group backstop. Three head-chain consumers (`int_attestation_attested_head`, `fct_attestation_correctness_head`, `fct_attestation_correctness_by_validator_head`) AND-depend on it and rely on the canonical union as a backfill backstop that fills committee slots whose head-event batches were lost to sentry outages; un-bolting it would strand them and reintroduce committee gaps (phantom 'missed' attestations) in backfilled history. Since head and canonical content are identical for committees, the safe path is to add the explicit merge for new/settled consumers and keep `_head` real-time-with-backstop. Pending (serial, shared CBT infra): make proto for the new table, generate overlapping head+canonical test fixtures, run the test harness.