### PR TITLE
refactor(proposer): un-bolt fct_block_proposer_head back to pure head (canonical lives in the merge)

### DIFF
--- a/models/transformations/fct_block_proposer_head.sql
+++ b/models/transformations/fct_block_proposer_head.sql
@@ -15,21 +15,15 @@ tags:
 dependencies:
   - "{{external}}.beacon_api_eth_v1_events_block_gossip"
   - "{{external}}.beacon_api_eth_v1_events_block"
-  - - "{{external}}.beacon_api_eth_v1_proposer_duty"
-    - "{{external}}.canonical_beacon_proposer_duty"
+  - "{{external}}.beacon_api_eth_v1_proposer_duty"
   - "{{external}}.libp2p_gossipsub_beacon_block"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`
--- Proposer duties are deterministic per epoch (fixed by the RANDAO seed
--- epochs in advance), so the head-event stream and the canonical table can
--- never disagree on CONTENT, only on presence. Unioning canonical in makes
--- it a backstop: at the head its range is empty (it lags finalization) and
--- it contributes nothing, while in backfilled history it fills slots whose
--- head-event duty batches were lost to sentry outages. The two duty sources
--- form an OR-group dependency, so forwardfill is not capped at canonical's
--- lag. The outer DISTINCT collapses the union back to one row per slot
--- because the sources' content is identical.
+-- Pure real-time head: proposer duties are read only from the head-event
+-- stream. Canonical duty backfill is no longer unioned in here; the canonical
+-- backstop is provided downstream by the fct_block_proposer merge, which
+-- AND-depends on int_block_proposer_canonical alongside this head model.
 WITH proposer_duties AS (
     SELECT DISTINCT
         slot,
@@ -38,29 +32,9 @@ WITH proposer_duties AS (
         epoch_start_date_time,
         proposer_validator_index,
         proposer_pubkey
-    FROM (
-        SELECT
-            slot,
-            slot_start_date_time,
-            epoch,
-            epoch_start_date_time,
-            proposer_validator_index,
-            proposer_pubkey
-        FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_proposer_duty" "helpers" "from" }} FINAL
-        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
-            AND meta_network_name = '{{ .env.NETWORK }}'
-        UNION ALL
-        SELECT
-            slot,
-            slot_start_date_time,
-            epoch,
-            epoch_start_date_time,
-            proposer_validator_index,
-            proposer_pubkey
-        FROM {{ index .dep "{{external}}" "canonical_beacon_proposer_duty" "helpers" "from" }} FINAL
-        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
-            AND meta_network_name = '{{ .env.NETWORK }}'
-    )
+    FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_proposer_duty" "helpers" "from" }} FINAL
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+        AND meta_network_name = '{{ .env.NETWORK }}'
 ),
 
 -- Sentries publish a whole epoch's proposer duties as one batch around the
@@ -69,12 +43,12 @@ WITH proposer_duties AS (
 -- the slot loses its proposer pubkey, and a missed slot in the gap vanishes
 -- from the table entirely (nothing on either side of the join). Every slot
 -- has exactly one proposer, so completeness here is simply presence: require
--- every slot on the 12s grid inside the interval to have a duty row in the
--- union of both sources, and fail the task otherwise so the scheduler
--- retries once ingestion has settled.
+-- every slot on the 12s grid inside the interval to have a head-event duty
+-- row, and fail the task otherwise so the scheduler retries once ingestion
+-- has settled.
 --
--- These scans deliberately read the source tables directly (not
--- proposer_duties) and skip FINAL: duty PRESENCE is unaffected by
+-- This scan deliberately reads the source table directly (not
+-- proposer_duties) and skips FINAL: duty PRESENCE is unaffected by
 -- ReplacingMergeTree version replacement.
 --
 -- Bounds are not necessarily aligned to the 12s grid (backfill chunks are
@@ -92,11 +66,6 @@ duty_slots AS (
     FROM (
         SELECT slot, toUnixTimestamp(slot_start_date_time) AS slot_ts
         FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_proposer_duty" "helpers" "from" }}
-        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
-            AND meta_network_name = '{{ .env.NETWORK }}'
-        UNION ALL
-        SELECT slot, toUnixTimestamp(slot_start_date_time) AS slot_ts
-        FROM {{ index .dep "{{external}}" "canonical_beacon_proposer_duty" "helpers" "from" }}
         WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
             AND meta_network_name = '{{ .env.NETWORK }}'
     )
@@ -211,10 +180,9 @@ FROM proposer_duties pd
 GLOBAL FULL OUTER JOIN deduplicated_blocks db ON pd.slot = db.slot
 -- The gate protects against ingestion RACES, which settle within seconds
 -- (emit-to-queryable p999 is under 30s). An interval whose end is more than
--- an hour old is settled: a slot absent from BOTH the head-event stream and
--- the canonical table by then is permanently absent, and refusing it forever
--- would wedge backfill at the first such gap. For settled intervals, bake
--- what exists.
+-- an hour old is settled: a slot absent from the head-event stream by then is
+-- permanently absent at the head, and refusing it forever would stall backfill
+-- at the first such gap. For settled intervals, bake what exists.
 WHERE (
     SELECT throwIf(
         missing_slots > 0

--- a/tests/mainnet/models/fct_block_proposer_head.yaml
+++ b/tests/mainnet/models/fct_block_proposer_head.yaml
@@ -10,9 +10,6 @@ external_data:
     beacon_api_eth_v1_proposer_duty:
         url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_block_proposer_head_beacon_api_eth_v1_proposer_duty.parquet
         network_column: meta_network_name
-    canonical_beacon_proposer_duty:
-        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/canonical_beacon_proposer_duty.parquet
-        network_column: meta_network_name
     libp2p_gossipsub_beacon_block:
         url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_block_proposer_head_libp2p_gossipsub_beacon_block.parquet
         network_column: meta_network_name


### PR DESCRIPTION
Reverts the canonical proposer-duty backstop that #267 bolted onto `fct_block_proposer_head`. The OR-group duty dependency collapses back to a single `beacon_api_eth_v1_proposer_duty` source, and the `canonical_beacon_proposer_duty` UNION ALL branch is removed from both the `proposer_duties` CTE and the `duty_slots` completeness-gate CTE, leaving `fct_block_proposer_head` as a pure real-time head view. This restores the unsuffixed-merge convention: canonical duty backfill is provided by `int_block_proposer_canonical`, which the already-existing `fct_block_proposer` merge (migration 004) AND-depends on alongside this head model and prefers per slot via CASE on block_root — so un-bolting the head does not strand the merge. The gate's `throwIf` stays, now gating only on beacon_api duty presence. The unused `canonical_beacon_proposer_duty` fixture is dropped from the head test. Cascade note: `fct_block_proposer` and the two head correctness models (`fct_attestation_correctness_head`, `fct_attestation_correctness_by_validator_head`) are safe; `fct_block_proposer_entity` (AND-deps head + dim_node) loses the canonical duty backstop and may want re-pointing to the `fct_block_proposer` merge — flagged for the author to decide, not changed here. Pending infra steps (serial, run afterward): regenerate overlapping head duty fixtures, and run the test harness against the reverted model.