### PR TITLE
fix(fct_block_blob_head): source from live beacon_api_eth_v1_beacon_blob

### DIFF
--- a/models/transformations/fct_block_blob_head.sql
+++ b/models/transformations/fct_block_blob_head.sql
@@ -12,21 +12,21 @@ tags:
   - block
   - blob
 dependencies:
-  - "{{external}}.beacon_api_eth_v1_events_blob_sidecar"
+  - "{{external}}.beacon_api_eth_v1_beacon_blob"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`
 SELECT
     fromUnixTimestamp({{ .task.start }}) as updated_date_time,
-    argMin(slot, propagation_slot_start_diff) AS slot,
+    any(slot) AS slot,
     slot_start_date_time,
-    argMin(epoch, propagation_slot_start_diff) AS epoch,
-    argMin(epoch_start_date_time, propagation_slot_start_diff) AS epoch_start_date_time,
+    any(epoch) AS epoch,
+    any(epoch_start_date_time) AS epoch_start_date_time,
     block_root,
     blob_index,
-    argMin(versioned_hash, propagation_slot_start_diff) AS versioned_hash,
-    argMin(kzg_commitment, propagation_slot_start_diff) AS kzg_commitment
-FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_events_blob_sidecar" "helpers" "from" }} FINAL
+    any(versioned_hash) AS versioned_hash,
+    any(kzg_commitment) AS kzg_commitment
+FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_beacon_blob" "helpers" "from" }} FINAL
 WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
     AND meta_network_name = '{{ .env.NETWORK }}'
 GROUP BY slot_start_date_time, block_root, blob_index

--- a/tests/mainnet/models/fct_block_blob_head.yaml
+++ b/tests/mainnet/models/fct_block_blob_head.yaml
@@ -1,8 +1,8 @@
 model: fct_block_blob_head
 network: mainnet
 external_data:
-    beacon_api_eth_v1_events_blob_sidecar:
-        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_block_blob_head_beacon_api_eth_v1_events_blob_sidecar_v2.parquet
+    beacon_api_eth_v1_beacon_blob:
+        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_block_blob_head_beacon_api_eth_v1_beacon_blob.parquet
         network_column: meta_network_name
 assertions:
     - name: Row count should be greater than zero
@@ -12,7 +12,7 @@ assertions:
         - type: greater_than
           column: row_count
           value: 0
-    - name: Slot values should be non-negative
+    - name: No negative slot values
       sql: |
         SELECT COUNT(*) AS bad_rows FROM fct_block_blob_head FINAL
         WHERE slot < 0
@@ -20,7 +20,7 @@ assertions:
         - type: equals
           column: bad_rows
           value: 0
-    - name: Epoch values should be non-negative
+    - name: No negative epoch values
       sql: |
         SELECT COUNT(*) AS bad_rows FROM fct_block_blob_head FINAL
         WHERE epoch < 0
@@ -28,15 +28,7 @@ assertions:
         - type: equals
           column: bad_rows
           value: 0
-    - name: Blob index should be non-negative
-      sql: |
-        SELECT COUNT(*) AS bad_rows FROM fct_block_blob_head FINAL
-        WHERE blob_index < 0
-      assertions:
-        - type: equals
-          column: bad_rows
-          value: 0
-    - name: Epoch should equal floor of slot divided by 32
+    - name: Epoch equals slot divided by 32
       sql: |
         SELECT COUNT(*) AS bad_rows FROM fct_block_blob_head FINAL
         WHERE epoch != intDiv(slot, 32)
@@ -44,7 +36,15 @@ assertions:
         - type: equals
           column: bad_rows
           value: 0
-    - name: No null or empty block roots
+    - name: No negative blob_index values
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_block_blob_head FINAL
+        WHERE blob_index < 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Block root must not be empty
       sql: |
         SELECT COUNT(*) AS bad_rows FROM fct_block_blob_head FINAL
         WHERE block_root = '' OR block_root IS NULL
@@ -52,7 +52,7 @@ assertions:
         - type: equals
           column: bad_rows
           value: 0
-    - name: No null or empty versioned hashes
+    - name: Versioned hash must not be empty
       sql: |
         SELECT COUNT(*) AS bad_rows FROM fct_block_blob_head FINAL
         WHERE versioned_hash = '' OR versioned_hash IS NULL
@@ -60,7 +60,7 @@ assertions:
         - type: equals
           column: bad_rows
           value: 0
-    - name: No null or empty kzg commitments
+    - name: KZG commitment must not be empty
       sql: |
         SELECT COUNT(*) AS bad_rows FROM fct_block_blob_head FINAL
         WHERE kzg_commitment = '' OR kzg_commitment IS NULL
@@ -68,19 +68,19 @@ assertions:
         - type: equals
           column: bad_rows
           value: 0
-    - name: Block root, blob index and slot combination should be unique
+    - name: No duplicate slot block_root blob_index combinations
       sql: |
-        SELECT COUNT(*) AS duplicate_groups FROM (
-          SELECT slot_start_date_time, block_root, blob_index, COUNT(*) AS cnt
+        SELECT COUNT(*) AS dup_groups FROM (
+          SELECT slot_start_date_time, block_root, blob_index
           FROM fct_block_blob_head FINAL
           GROUP BY slot_start_date_time, block_root, blob_index
-          HAVING cnt > 1
+          HAVING COUNT(*) > 1
         )
       assertions:
         - type: equals
-          column: duplicate_groups
+          column: dup_groups
           value: 0
-    - name: Epoch start time should be less than or equal to slot start time
+    - name: Epoch start time must not be after slot start time
       sql: |
         SELECT COUNT(*) AS bad_rows FROM fct_block_blob_head FINAL
         WHERE epoch_start_date_time > slot_start_date_time


### PR DESCRIPTION
The original source `beacon_api_eth_v1_events_blob_sidecar` (sentry blob-sidecar event stream) stopped flowing on 2025-12-03, so the freshly-shipped `fct_block_blob_head` had no data past that date — the established `fct_block_blob_first_seen_by_node` ends at the same timestamp, confirming a source outage. Switch to `beacon_api_eth_v1_beacon_blob` (the beacon-API blob-sidecar fetch), a live head source (lag 12 slots, ~2.4 min) that carries `versioned_hash` and `kzg_commitment` per `(slot, block_root, blob_index)`; the model dedups the per-sentry observations with `any()`. Output schema is unchanged, so no migration/proto/cbt-api change is needed — only the engine image bump after merge. Test re-seeded from the new source (4929 rows).