### PR TITLE
feat(infra): instance-scoped infra via --project-name for concurrent stacks

### DIFF
--- a/cmd/infra.go
+++ b/cmd/infra.go
@@ -25,6 +25,8 @@ import (
 const (
 	xatuModeLocal    = "local"
 	xatuModeExternal = "external"
+
+	xatuClickHouseService = "xatu-clickhouse-01"
 )
 
 var (
@@ -34,9 +36,11 @@ var (
 	infraRedisURL       string
 	infraRunMigrations  bool
 	infraXatuRef        string
+	infraProjectName    string
 
-	errInvalidXatuMode = errors.New("invalid xatu-mode")
-	errXatuURLRequired = errors.New("xatu-url is required when xatu-source is external")
+	errInvalidXatuMode  = errors.New("invalid xatu-mode")
+	errXatuURLRequired  = errors.New("xatu-url is required when xatu-source is external")
+	errProjectNameEmpty = errors.New("project-name cannot be empty")
 )
 
 // infraCmd represents the infrastructure command
@@ -136,8 +140,9 @@ func init() {
 	infraCmd.AddCommand(infraResetCmd)
 	infraCmd.AddCommand(infraMigrateXatuCmd)
 	infraMigrateXatuCmd.Flags().StringVar(&infraXatuRef, "xatu-ref", config.XatuDefaultRef, "Xatu repository ref (branch/tag/commit)")
+	infraCmd.PersistentFlags().StringVar(&infraProjectName, "project-name", config.GetProjectName(), fmt.Sprintf("Docker Compose project name (env %s)", config.ProjectNameEnvVar))
 	infraCmd.PersistentFlags().StringVar(&infraClickhouseURL, "clickhouse-url", config.GetCBTClickHouseURL(), "CBT ClickHouse cluster URL")
-	infraCmd.PersistentFlags().StringVar(&infraRedisURL, "redis-url", config.DefaultRedisURL, "Redis connection URL")
+	infraCmd.PersistentFlags().StringVar(&infraRedisURL, "redis-url", config.GetRedisURL(), "Redis connection URL")
 	infraStopCmd.Flags().BoolVar(&infraCleanupTestDBs, "cleanup-test-dbs", true, "Cleanup ephemeral test databases")
 	infraStatusCmd.Flags().BoolVar(&infraVerbose, "verbose", false, "Show detailed container and database information")
 	infraStartCmd.Flags().String("xatu-source", xatuModeLocal, "Xatu data source: 'local' (start local cluster) or 'external' (connect to remote)")
@@ -146,12 +151,26 @@ func init() {
 	infraStartCmd.Flags().StringVar(&infraXatuRef, "xatu-ref", config.XatuDefaultRef, "Xatu repository ref (branch/tag/commit)")
 }
 
+func resolveInfraProjectName() (string, error) {
+	projectName := strings.TrimSpace(infraProjectName)
+	if projectName == "" {
+		return "", errProjectNameEmpty
+	}
+
+	return projectName, nil
+}
+
 // createInfraManagers creates and returns Docker and ClickHouse managers with the shared configuration.
-func createInfraManagers(log logrus.FieldLogger) (infra.DockerManager, infra.ClickHouseManager) {
+func createInfraManagers(log logrus.FieldLogger) (infra.DockerManager, infra.ClickHouseManager, error) {
+	projectName, err := resolveInfraProjectName()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	dockerManager := infra.NewDockerManager(
 		log,
 		config.PlatformComposeFile,
-		config.ProjectName,
+		projectName,
 	)
 
 	// Load config to get safe hostnames for infrastructure management
@@ -168,7 +187,7 @@ func createInfraManagers(log logrus.FieldLogger) (infra.DockerManager, infra.Cli
 		cfg.SafeHostnames,
 	)
 
-	return dockerManager, chManager
+	return dockerManager, chManager, nil
 }
 
 // ensureXatuRepo ensures the xatu repository exists and returns its path.
@@ -257,7 +276,10 @@ func runInfraStart(cmd *cobra.Command, _ []string) error {
 		log.Info("skipping local Xatu cluster (external source)")
 	}
 
-	dockerManager, chManager := createInfraManagers(log)
+	dockerManager, chManager, err := createInfraManagers(log)
+	if err != nil {
+		return err
+	}
 
 	// Start infrastructure with profiles
 	if startErr := chManager.Start(ctx, profiles...); startErr != nil {
@@ -271,7 +293,7 @@ func runInfraStart(cmd *cobra.Command, _ []string) error {
 
 	// Run migrations if requested
 	if infraRunMigrations {
-		if migErr := handleInfraMigrations(ctx, log, xatuSource); migErr != nil {
+		if migErr := handleInfraMigrations(ctx, log, dockerManager, xatuSource); migErr != nil {
 			return migErr
 		}
 	}
@@ -329,7 +351,10 @@ func runInfraStop(_ *cobra.Command, _ []string) error {
 	log := newLogger(false)
 	log.Info("stopping platform infrastructure")
 
-	dockerManager, chManager := createInfraManagers(log)
+	dockerManager, chManager, err := createInfraManagers(log)
+	if err != nil {
+		return err
+	}
 
 	running, err := dockerManager.IsRunning(ctx)
 	if err != nil {
@@ -364,7 +389,10 @@ func runInfraStatus(_ *cobra.Command, _ []string) error {
 
 	log := newLogger(infraVerbose)
 
-	dockerManager, chManager := createInfraManagers(log)
+	dockerManager, chManager, err := createInfraManagers(log)
+	if err != nil {
+		return err
+	}
 
 	running, err := dockerManager.IsRunning(ctx)
 	if err != nil {
@@ -401,7 +429,10 @@ func runInfraReset(_ *cobra.Command, _ []string) error {
 
 	log.Info("Resetting platform infrastructure")
 
-	dockerManager, _ := createInfraManagers(log)
+	dockerManager, _, err := createInfraManagers(log)
+	if err != nil {
+		return err
+	}
 
 	// Pass all known profiles to ensure complete cleanup
 	// This ensures profiled containers (like xatu-clickhouse) are also removed
@@ -416,7 +447,7 @@ func runInfraReset(_ *cobra.Command, _ []string) error {
 }
 
 // handleInfraMigrations orchestrates migrations for infrastructure startup.
-func handleInfraMigrations(ctx context.Context, log logrus.FieldLogger, xatuSource string) error {
+func handleInfraMigrations(ctx context.Context, log logrus.FieldLogger, dockerManager infra.DockerManager, xatuSource string) error {
 	fmt.Println("\n🔄 Running migrations...")
 
 	xatuRepoPath, repoErr := getXatuRepoPathForMigrations(log, xatuSource)
@@ -424,7 +455,7 @@ func handleInfraMigrations(ctx context.Context, log logrus.FieldLogger, xatuSour
 		return repoErr
 	}
 
-	if migErr := runInfraMigrations(ctx, log, xatuSource, xatuRepoPath); migErr != nil {
+	if migErr := runInfraMigrations(ctx, log, dockerManager, xatuSource, xatuRepoPath); migErr != nil {
 		return fmt.Errorf("running migrations: %w", migErr)
 	}
 
@@ -453,14 +484,23 @@ func getXatuRepoPathForMigrations(log logrus.FieldLogger, xatuSource string) (st
 }
 
 // runInfraMigrations runs migrations for both Xatu and CBT clusters.
-func runInfraMigrations(ctx context.Context, log logrus.FieldLogger, xatuSource, xatuRepoPath string) error {
+func runInfraMigrations(ctx context.Context, log logrus.FieldLogger, dockerManager infra.DockerManager, xatuSource, xatuRepoPath string) error {
+	projectName, projectErr := resolveInfraProjectName()
+	if projectErr != nil {
+		return projectErr
+	}
+
 	// Run Xatu migrations (only for local mode)
 	if xatuSource == xatuModeLocal && xatuRepoPath != "" {
 		fmt.Println("  → Running Xatu cluster migrations...")
 
 		xatuMigrationDir := fmt.Sprintf("%s/%s", xatuRepoPath, config.XatuMigrationsPath)
+		xatuConnStr, connErr := resolveXatuMigrationConnStr(ctx, dockerManager, projectName)
+		if connErr != nil {
+			return connErr
+		}
 
-		if err := runXatuMigrations(ctx, log, xatuMigrationDir); err != nil {
+		if err := runXatuMigrations(ctx, log, xatuMigrationDir, xatuConnStr); err != nil {
 			return fmt.Errorf("xatu migrations: %w", err)
 		}
 
@@ -469,6 +509,12 @@ func runInfraMigrations(ctx context.Context, log logrus.FieldLogger, xatuSource,
 
 	// Run CBT migrations
 	fmt.Println("  → Running CBT cluster migrations...")
+
+	restoreEnv, targetErr := configureCBTMigrationTarget(ctx, dockerManager, projectName)
+	if targetErr != nil {
+		return targetErr
+	}
+	defer restoreEnv()
 
 	if err := actions.Setup(false, true); err != nil {
 		return fmt.Errorf("cbt migrations: %w", err)
@@ -488,6 +534,16 @@ func runInfraMigrateXatu(_ *cobra.Command, _ []string) error {
 
 	log := newLogger(false)
 
+	dockerManager, _, err := createInfraManagers(log)
+	if err != nil {
+		return err
+	}
+
+	projectName, err := resolveInfraProjectName()
+	if err != nil {
+		return err
+	}
+
 	wd, wdErr := os.Getwd()
 	if wdErr != nil {
 		return fmt.Errorf("getting working directory: %w", wdErr)
@@ -499,10 +555,14 @@ func runInfraMigrateXatu(_ *cobra.Command, _ []string) error {
 	}
 
 	baseMigrationDir := filepath.Join(xatuRepoPath, config.XatuMigrationsPath)
+	xatuConnStr, connErr := resolveXatuMigrationConnStr(ctx, dockerManager, projectName)
+	if connErr != nil {
+		return connErr
+	}
 
 	fmt.Println("→ Running Xatu cluster migrations...")
 
-	if err := runXatuMigrations(ctx, log, baseMigrationDir); err != nil {
+	if err := runXatuMigrations(ctx, log, baseMigrationDir, xatuConnStr); err != nil {
 		return fmt.Errorf("xatu migrations: %w", err)
 	}
 
@@ -511,13 +571,72 @@ func runInfraMigrateXatu(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
+func configureCBTMigrationTarget(ctx context.Context, dockerManager infra.DockerManager, projectName string) (func(), error) {
+	published, err := dockerManager.GetServicePort(ctx, config.ClickHouseContainer, config.ClickHouseContainerNativePort)
+	if err != nil {
+		return nil, fmt.Errorf("resolving CBT migration target for project %q: %w", projectName, err)
+	}
+
+	return applyEnv(map[string]string{
+		"CLICKHOUSE_HOST":                      published.Host,
+		config.ClickHouseCBT01NativePortEnvVar: published.Port,
+	}), nil
+}
+
+func resolveXatuMigrationConnStr(ctx context.Context, dockerManager infra.DockerManager, projectName string) (string, error) {
+	published, err := dockerManager.GetServicePort(ctx, xatuClickHouseService, config.ClickHouseContainerNativePort, "xatu-local")
+	if err != nil {
+		return "", fmt.Errorf("resolving Xatu migration target for project %q: %w", projectName, err)
+	}
+
+	return clickHouseURLForPublishedPort(published), nil
+}
+
+func clickHouseURLForPublishedPort(published infra.PublishedPort) string {
+	username := os.Getenv("CLICKHOUSE_USERNAME")
+	if username == "" {
+		username = "default"
+	}
+
+	password := os.Getenv("CLICKHOUSE_PASSWORD")
+	if password == "" {
+		password = "supersecret"
+	}
+
+	return fmt.Sprintf("clickhouse://%s:%s@%s:%s", username, password, published.Host, published.Port)
+}
+
+func applyEnv(overrides map[string]string) func() {
+	previous := make(map[string]*string, len(overrides))
+
+	for key, value := range overrides {
+		if current, ok := os.LookupEnv(key); ok {
+			currentCopy := current
+			previous[key] = &currentCopy
+		} else {
+			previous[key] = nil
+		}
+
+		_ = os.Setenv(key, value)
+	}
+
+	return func() {
+		for key, value := range previous {
+			if value == nil {
+				_ = os.Unsetenv(key)
+				continue
+			}
+
+			_ = os.Setenv(key, *value)
+		}
+	}
+}
+
 // runXatuMigrations runs xatu's per-schema migration sets against the Xatu
 // ClickHouse cluster. Each set is database-agnostic and applied to its target
 // database, tracked in its own schema_migrations_<set> table. baseMigrationDir is
 // the root migrations directory; each set lives in a subdirectory below it.
-func runXatuMigrations(ctx context.Context, log logrus.FieldLogger, baseMigrationDir string) error {
-	xatuConnStr := config.GetXatuClickHouseURL()
-
+func runXatuMigrations(ctx context.Context, log logrus.FieldLogger, baseMigrationDir, xatuConnStr string) error {
 	// Open connection to Xatu cluster
 	conn, openErr := sql.Open("clickhouse", xatuConnStr)
 	if openErr != nil {

--- a/cmd/infra_test.go
+++ b/cmd/infra_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/ethpandaops/xatu-cbt/internal/config"
+	"github.com/ethpandaops/xatu-cbt/internal/infra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureCBTMigrationTargetCustomProjectUsesPublishedPort(t *testing.T) {
+	dockerManager := &fakeDockerManager{
+		publishedPort: infra.PublishedPort{Host: "127.0.0.1", Port: "9100"},
+	}
+	t.Setenv("CLICKHOUSE_HOST", "localhost")
+	t.Setenv(config.ClickHouseCBT01NativePortEnvVar, "9000")
+
+	restoreEnv, err := configureCBTMigrationTarget(context.Background(), dockerManager, "a")
+
+	require.NoError(t, err)
+	require.Equal(t, config.ClickHouseContainer, dockerManager.service)
+	require.Equal(t, config.ClickHouseContainerNativePort, dockerManager.targetPort)
+	require.Equal(t, "127.0.0.1", getTestEnv(t, "CLICKHOUSE_HOST"))
+	require.Equal(t, "9100", getTestEnv(t, config.ClickHouseCBT01NativePortEnvVar))
+
+	restoreEnv()
+	require.Equal(t, "localhost", getTestEnv(t, "CLICKHOUSE_HOST"))
+	require.Equal(t, "9000", getTestEnv(t, config.ClickHouseCBT01NativePortEnvVar))
+}
+
+func TestResolveXatuMigrationConnStrCustomProjectUsesPublishedPort(t *testing.T) {
+	dockerManager := &fakeDockerManager{
+		publishedPort: infra.PublishedPort{Host: "127.0.0.1", Port: "9202"},
+	}
+	t.Setenv("CLICKHOUSE_USERNAME", "")
+	t.Setenv("CLICKHOUSE_PASSWORD", "")
+
+	connStr, err := resolveXatuMigrationConnStr(context.Background(), dockerManager, "a")
+
+	require.NoError(t, err)
+	require.Equal(t, xatuClickHouseService, dockerManager.service)
+	require.Equal(t, config.ClickHouseContainerNativePort, dockerManager.targetPort)
+	require.Equal(t, []string{"xatu-local"}, dockerManager.profiles)
+	require.Equal(t, "clickhouse://default:supersecret@127.0.0.1:9202", connStr)
+}
+
+func TestResolveXatuMigrationConnStrDefaultProjectUsesPublishedPort(t *testing.T) {
+	dockerManager := &fakeDockerManager{
+		publishedPort: infra.PublishedPort{Host: "127.0.0.1", Port: "9202"},
+	}
+	t.Setenv("CLICKHOUSE_HOST", "")
+	t.Setenv("CLICKHOUSE_USERNAME", "")
+	t.Setenv("CLICKHOUSE_PASSWORD", "")
+	t.Setenv(config.ClickHouseNativePortEnvVar, "")
+	t.Setenv(config.ClickHouseXatu01NativePortEnvVar, "9302")
+
+	connStr, err := resolveXatuMigrationConnStr(context.Background(), dockerManager, config.ProjectName)
+
+	require.NoError(t, err)
+	require.Equal(t, xatuClickHouseService, dockerManager.service)
+	require.Equal(t, config.ClickHouseContainerNativePort, dockerManager.targetPort)
+	require.Equal(t, []string{"xatu-local"}, dockerManager.profiles)
+	require.Equal(t, "clickhouse://default:supersecret@127.0.0.1:9202", connStr)
+}
+
+type fakeDockerManager struct {
+	publishedPort infra.PublishedPort
+	service       string
+	targetPort    string
+	profiles      []string
+}
+
+func (m *fakeDockerManager) Start(context.Context, ...string) error {
+	return nil
+}
+
+func (m *fakeDockerManager) Stop(...string) error {
+	return nil
+}
+
+func (m *fakeDockerManager) Reset(...string) error {
+	return nil
+}
+
+func (m *fakeDockerManager) IsRunning(context.Context) (bool, error) {
+	return false, nil
+}
+
+func (m *fakeDockerManager) GetContainerStatus(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (m *fakeDockerManager) GetAllServices(context.Context) ([]infra.ServiceInfo, error) {
+	return nil, nil
+}
+
+func (m *fakeDockerManager) GetServicePort(_ context.Context, service, targetPort string, profiles ...string) (infra.PublishedPort, error) {
+	m.service = service
+	m.targetPort = targetPort
+	m.profiles = profiles
+
+	return m.publishedPort, nil
+}
+
+func getTestEnv(t *testing.T, key string) string {
+	t.Helper()
+
+	value, ok := os.LookupEnv(key)
+	require.True(t, ok)
+
+	return value
+}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -135,7 +135,7 @@ func init() {
 	testCmd.PersistentFlags().BoolVar(&testCleanupTestDB, "cleanup-test-db", false, "Cleanup test database on completion (useful for CI, disabled by default for debugging)")
 	testCmd.PersistentFlags().StringVar(&xatuClickhouseURL, "xatu-clickhouse-url", config.GetXatuClickHouseURL(), "Xatu ClickHouse cluster URL (external data)")
 	testCmd.PersistentFlags().StringVar(&cbtClickhouseURL, "cbt-clickhouse-url", config.GetCBTClickHouseURL(), "CBT ClickHouse cluster URL (transformations)")
-	testCmd.PersistentFlags().StringVar(&redisURL, "redis-url", config.DefaultRedisURL, "Redis connection URL")
+	testCmd.PersistentFlags().StringVar(&redisURL, "redis-url", config.GetRedisURL(), "Redis connection URL")
 	testCmd.PersistentFlags().StringVar(&xatuRepoURL, "xatu-repo", config.XatuRepoURL, "Xatu repository URL")
 	testCmd.PersistentFlags().StringVar(&xatuRef, "xatu-ref", config.XatuDefaultRef, "Xatu repository ref (branch/tag/commit)")
 }

--- a/docker-compose.platform.yml
+++ b/docker-compose.platform.yml
@@ -44,26 +44,17 @@
 
 networks:
   xatu-net:
-    name: xatu_xatu-net
     driver: bridge
 
 volumes:
-  clickhouse-01-data:
-    name: xatu-cbt-clickhouse-01-data
-  clickhouse-02-data:
-    name: xatu-cbt-clickhouse-02-data
-  xatu-clickhouse-01-data:
-    name: xatu-clickhouse-01-data
-  xatu-clickhouse-02-data:
-    name: xatu-clickhouse-02-data
-  clickhouse-keeper-01-data:
-    name: xatu-cbt-clickhouse-keeper-01-data
-  clickhouse-keeper-02-data:
-    name: xatu-cbt-clickhouse-keeper-02-data
-  clickhouse-keeper-03-data:
-    name: xatu-cbt-clickhouse-keeper-03-data
-  redis-data:
-    name: xatu-cbt-redis-data
+  clickhouse-01-data: {}
+  clickhouse-02-data: {}
+  xatu-clickhouse-01-data: {}
+  xatu-clickhouse-02-data: {}
+  clickhouse-keeper-01-data: {}
+  clickhouse-keeper-02-data: {}
+  clickhouse-keeper-03-data: {}
+  redis-data: {}
 
 services:
   # ---------------------------------------------------------------------------
@@ -72,7 +63,6 @@ services:
   # ---------------------------------------------------------------------------
   xatu-cbt-clickhouse-keeper-01:
     image: clickhouse/clickhouse-keeper:${CLICKHOUSE_VERSION:-26.2.5.45}
-    container_name: xatu-cbt-clickhouse-keeper-01
     hostname: xatu-cbt-clickhouse-keeper-01
     networks:
       - xatu-net
@@ -89,7 +79,6 @@ services:
 
   xatu-cbt-clickhouse-keeper-02:
     image: clickhouse/clickhouse-keeper:${CLICKHOUSE_VERSION:-26.2.5.45}
-    container_name: xatu-cbt-clickhouse-keeper-02
     hostname: xatu-cbt-clickhouse-keeper-02
     networks:
       - xatu-net
@@ -106,7 +95,6 @@ services:
 
   xatu-cbt-clickhouse-keeper-03:
     image: clickhouse/clickhouse-keeper:${CLICKHOUSE_VERSION:-26.2.5.45}
-    container_name: xatu-cbt-clickhouse-keeper-03
     hostname: xatu-cbt-clickhouse-keeper-03
     networks:
       - xatu-net
@@ -127,7 +115,6 @@ services:
   # ---------------------------------------------------------------------------
   xatu-cbt-clickhouse-01:
     image: clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-26.2.5.45}
-    container_name: xatu-cbt-clickhouse-01
     hostname: xatu-cbt-clickhouse-01
     user: "101:101"
     extra_hosts:
@@ -165,7 +152,6 @@ services:
 
   xatu-cbt-clickhouse-02:
     image: clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-26.2.5.45}
-    container_name: xatu-cbt-clickhouse-02
     hostname: xatu-cbt-clickhouse-02
     user: "101:101"
     extra_hosts:
@@ -211,7 +197,6 @@ services:
     profiles:
       - xatu-local
     image: clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-26.2.5.45}
-    container_name: xatu-clickhouse-01
     hostname: xatu-clickhouse-01
     user: "101:101"
     networks:
@@ -249,7 +234,6 @@ services:
     profiles:
       - xatu-local
     image: clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-26.2.5.45}
-    container_name: xatu-clickhouse-02
     hostname: xatu-clickhouse-02
     user: "101:101"
     networks:
@@ -286,7 +270,6 @@ services:
   # Redis for CBT state management
   xatu-cbt-redis:
     image: redis:${REDIS_VERSION:-7-alpine}
-    container_name: xatu-cbt-redis
     hostname: xatu-cbt-redis
     networks:
       - xatu-net

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -45,10 +45,12 @@ func Load() (*AppConfig, error) {
 		SafeHostnames:      safeHostnames,
 	}
 
-	// Parse numeric values
-	nativePort, err := strconv.Atoi(getEnv("CLICKHOUSE_NATIVE_PORT", "9000"))
+	// Parse numeric values. CBT setup/migrations must target the same host port
+	// docker-compose.platform.yml publishes for CBT node 01.
+	nativePortValue, nativePortKey := getFirstEnv([]string{ClickHouseCBT01NativePortEnvVar, ClickHouseNativePortEnvVar}, "9000")
+	nativePort, err := strconv.Atoi(nativePortValue)
 	if err != nil {
-		return nil, fmt.Errorf("invalid CLICKHOUSE_NATIVE_PORT: %w", err)
+		return nil, fmt.Errorf("invalid %s: %w", nativePortKey, err)
 	}
 	cfg.ClickhouseNativePort = nativePort
 
@@ -108,14 +110,7 @@ func GetCBTClickHouseURL() string {
 		host = "localhost"
 	}
 
-	// Check specific port for CBT cluster, then generic, then default
-	port := os.Getenv("CLICKHOUSE_CBT_01_NATIVE_PORT")
-	if port == "" {
-		port = os.Getenv("CLICKHOUSE_NATIVE_PORT")
-	}
-	if port == "" {
-		port = "9000"
-	}
+	port := getCBTNativePort()
 
 	return fmt.Sprintf("clickhouse://%s:%s@%s:%s", username, password, host, port)
 }
@@ -137,16 +132,33 @@ func GetXatuClickHouseURL() string {
 		host = "localhost"
 	}
 
-	// Check specific port for Xatu cluster, then generic, then default
-	port := os.Getenv("CLICKHOUSE_XATU_01_NATIVE_PORT")
-	if port == "" {
-		port = os.Getenv("CLICKHOUSE_NATIVE_PORT")
-	}
-	if port == "" {
-		port = "9002"
-	}
+	port := getXatuNativePort()
 
 	return fmt.Sprintf("clickhouse://%s:%s@%s:%s", username, password, host, port)
+}
+
+// GetRedisURL returns the Redis connection URL built from the compose host port.
+func GetRedisURL() string {
+	return fmt.Sprintf("redis://localhost:%s", getEnv(RedisPortEnvVar, "6380"))
+}
+
+// GetProjectName returns the Docker Compose project name, falling back to the default project.
+func GetProjectName() string {
+	return getEnv(ProjectNameEnvVar, ProjectName)
+}
+
+// GetDockerNetworkName returns the Docker Compose-managed network name for the project.
+func GetDockerNetworkName() string {
+	return fmt.Sprintf("%s_xatu-net", GetProjectName())
+}
+
+func getCBTNativePort() string {
+	port, _ := getFirstEnv([]string{ClickHouseCBT01NativePortEnvVar, ClickHouseNativePortEnvVar}, "9000")
+	return port
+}
+
+func getXatuNativePort() string {
+	return getEnv(ClickHouseXatu01NativePortEnvVar, "9002")
 }
 
 func getEnv(key, defaultValue string) string {
@@ -154,6 +166,20 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+func getFirstEnv(keys []string, defaultValue string) (string, string) {
+	for _, key := range keys {
+		if value := os.Getenv(key); value != "" {
+			return value, key
+		}
+	}
+
+	if len(keys) == 0 {
+		return defaultValue, ""
+	}
+
+	return defaultValue, keys[0]
 }
 
 // parseSafeHostnames parses a comma-separated list of hostnames.

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -168,10 +168,10 @@ func getEnv(key, defaultValue string) string {
 	return defaultValue
 }
 
-func getFirstEnv(keys []string, defaultValue string) (string, string) {
+func getFirstEnv(keys []string, defaultValue string) (value, matchedKey string) {
 	for _, key := range keys {
-		if value := os.Getenv(key); value != "" {
-			return value, key
+		if v := os.Getenv(key); v != "" {
+			return v, key
 		}
 	}
 

--- a/internal/config/app_test.go
+++ b/internal/config/app_test.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadUsesCBTNativePortEnv(t *testing.T) {
+	clearConnectionEnv(t)
+	t.Chdir(t.TempDir())
+	t.Setenv(ClickHouseNativePortEnvVar, "9000")
+	t.Setenv(ClickHouseCBT01NativePortEnvVar, "9100")
+
+	cfg, err := Load()
+
+	require.NoError(t, err)
+	require.Equal(t, 9100, cfg.ClickhouseNativePort)
+}
+
+func TestLoadDefaultsCBTNativePort(t *testing.T) {
+	clearConnectionEnv(t)
+	t.Chdir(t.TempDir())
+
+	cfg, err := Load()
+
+	require.NoError(t, err)
+	require.Equal(t, 9000, cfg.ClickhouseNativePort)
+}
+
+func TestGetCBTClickHouseURLUsesCBTNativePortEnv(t *testing.T) {
+	clearConnectionEnv(t)
+	t.Setenv(ClickHouseNativePortEnvVar, "9000")
+	t.Setenv(ClickHouseCBT01NativePortEnvVar, "9100")
+
+	require.Equal(t, "clickhouse://default:supersecret@localhost:9100", GetCBTClickHouseURL())
+}
+
+func TestGetXatuClickHouseURLUsesXatuNativePortEnv(t *testing.T) {
+	clearConnectionEnv(t)
+	t.Setenv(ClickHouseNativePortEnvVar, "9000")
+	t.Setenv(ClickHouseXatu01NativePortEnvVar, "9202")
+
+	require.Equal(t, "clickhouse://default:supersecret@localhost:9202", GetXatuClickHouseURL())
+}
+
+func TestGetXatuClickHouseURLDefaultsXatuNativePort(t *testing.T) {
+	clearConnectionEnv(t)
+
+	require.Equal(t, "clickhouse://default:supersecret@localhost:9002", GetXatuClickHouseURL())
+}
+
+func TestGetXatuClickHouseURLIgnoresLegacyNativePort(t *testing.T) {
+	clearConnectionEnv(t)
+	t.Setenv(ClickHouseNativePortEnvVar, "9000")
+
+	require.Equal(t, "clickhouse://default:supersecret@localhost:9002", GetXatuClickHouseURL())
+}
+
+func TestGetRedisURLUsesRedisPortEnv(t *testing.T) {
+	clearConnectionEnv(t)
+	t.Setenv(RedisPortEnvVar, "7380")
+
+	require.Equal(t, "redis://localhost:7380", GetRedisURL())
+}
+
+func TestGetRedisURLDefaultsRedisPort(t *testing.T) {
+	clearConnectionEnv(t)
+
+	require.Equal(t, DefaultRedisURL, GetRedisURL())
+}
+
+func TestGetDockerNetworkNameUsesProjectName(t *testing.T) {
+	clearConnectionEnv(t)
+	t.Setenv(ProjectNameEnvVar, "a")
+
+	require.Equal(t, "a_xatu-net", GetDockerNetworkName())
+}
+
+func TestGetDockerNetworkNameDefaultsProjectName(t *testing.T) {
+	clearConnectionEnv(t)
+	t.Setenv(ProjectNameEnvVar, "")
+
+	require.Equal(t, "xatu-cbt-platform_xatu-net", GetDockerNetworkName())
+}
+
+func clearConnectionEnv(t *testing.T) {
+	t.Helper()
+
+	for _, key := range []string{
+		"CLICKHOUSE_HOST",
+		"CLICKHOUSE_USERNAME",
+		"CLICKHOUSE_PASSWORD",
+		ClickHouseNativePortEnvVar,
+		ClickHouseCBT01NativePortEnvVar,
+		ClickHouseXatu01NativePortEnvVar,
+		RedisPortEnvVar,
+		ProjectNameEnvVar,
+	} {
+		t.Setenv(key, "")
+	}
+}

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -10,18 +10,30 @@ const (
 	CBTClusterName = "cluster_2S_1R"
 	// ClickHouseLocalSuffix is the suffix appended to distributed table names to access local shards.
 	ClickHouseLocalSuffix = "_local"
-	// RedisContainerName is the name of the Redis container.
+	// RedisContainerName is the Redis Compose service name.
 	RedisContainerName = "xatu-cbt-redis"
 	// RedisContainerPort is the internal port Redis listens on within the container.
 	RedisContainerPort = "6379"
-	// ClickHouseContainer is the name of the CBT ClickHouse container.
+	// ClickHouseContainer is the CBT ClickHouse node 01 Compose service name.
 	ClickHouseContainer = "xatu-cbt-clickhouse-01"
 	// ClickHouseContainerHTTPPort is the internal HTTP port ClickHouse listens on within the container.
 	ClickHouseContainerHTTPPort = "8123"
+	// ClickHouseContainerNativePort is the internal native port ClickHouse listens on within the container.
+	ClickHouseContainerNativePort = "9000"
+	// ClickHouseNativePortEnvVar is the legacy ClickHouse native port environment variable.
+	ClickHouseNativePortEnvVar = "CLICKHOUSE_NATIVE_PORT"
+	// ClickHouseCBT01NativePortEnvVar is the CBT ClickHouse node 01 native host port environment variable.
+	ClickHouseCBT01NativePortEnvVar = "CLICKHOUSE_CBT_01_NATIVE_PORT"
+	// ClickHouseXatu01NativePortEnvVar is the Xatu ClickHouse node 01 native host port environment variable.
+	ClickHouseXatu01NativePortEnvVar = "CLICKHOUSE_XATU_01_NATIVE_PORT"
+	// RedisPortEnvVar is the Redis host port environment variable.
+	RedisPortEnvVar = "REDIS_PORT"
 	// PlatformComposeFile is the Docker Compose file for the platform infrastructure.
 	PlatformComposeFile = "docker-compose.platform.yml"
 	// ProjectName is the Docker Compose project name.
 	ProjectName = "xatu-cbt-platform"
+	// ProjectNameEnvVar is the environment variable used to override the Docker Compose project name.
+	ProjectNameEnvVar = "XATU_CBT_PROJECT_NAME"
 	// ModelsExternalDir is the directory path for external models.
 	ModelsExternalDir = "models/external"
 	// ModelsTransformationsDir is the directory path for transformation models.

--- a/internal/infra/docker.go
+++ b/internal/infra/docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os/exec"
 	"strings"
 	"time"
@@ -22,6 +23,12 @@ type ServiceInfo struct {
 	Ports  string
 }
 
+// PublishedPort holds a service port published on the host.
+type PublishedPort struct {
+	Host string
+	Port string
+}
+
 // DockerManager manages docker-compose lifecycle.
 type DockerManager interface {
 	Start(ctx context.Context, profiles ...string) error
@@ -30,6 +37,7 @@ type DockerManager interface {
 	IsRunning(ctx context.Context) (bool, error)
 	GetContainerStatus(ctx context.Context, service string) (string, error)
 	GetAllServices(ctx context.Context) ([]ServiceInfo, error)
+	GetServicePort(ctx context.Context, service, targetPort string, profiles ...string) (PublishedPort, error)
 }
 
 type dockerManager struct {
@@ -295,6 +303,38 @@ func (m *dockerManager) GetAllServices(ctx context.Context) ([]ServiceInfo, erro
 	return services, nil
 }
 
+// GetServicePort returns the host binding for a service target port.
+func (m *dockerManager) GetServicePort(ctx context.Context, service, targetPort string, profiles ...string) (PublishedPort, error) {
+	m.log.WithFields(logrus.Fields{
+		"service":     service,
+		"target_port": targetPort,
+	}).Debug("getting service port")
+
+	args := []string{
+		"compose",
+		"-f", m.composeFile,
+		"-p", m.projectName,
+	}
+
+	for _, profile := range profiles {
+		args = append(args, "--profile", profile)
+	}
+
+	args = append(args, "port", service, targetPort)
+
+	output, err := m.execComposeOutput(ctx, args...)
+	if err != nil {
+		return PublishedPort{}, fmt.Errorf("executing docker-compose port: %w", err)
+	}
+
+	published, err := parsePublishedPort(output)
+	if err != nil {
+		return PublishedPort{}, err
+	}
+
+	return published, nil
+}
+
 // execComposeOutput executes a docker-compose command and returns output.
 func (m *dockerManager) execComposeOutput(ctx context.Context, args ...string) ([]byte, error) {
 	execCtx, cancel := context.WithTimeout(ctx, commandTimeout)
@@ -309,4 +349,31 @@ func (m *dockerManager) execComposeOutput(ctx context.Context, args ...string) (
 	}
 
 	return output, nil
+}
+
+func parsePublishedPort(output []byte) (PublishedPort, error) {
+	line := strings.TrimSpace(string(output))
+	if line == "" {
+		return PublishedPort{}, fmt.Errorf("empty docker-compose port output") //nolint:err113 // Includes command context from caller.
+	}
+
+	firstLine := strings.Split(line, "\n")[0]
+	host, port, err := net.SplitHostPort(firstLine)
+	if err != nil {
+		return PublishedPort{}, fmt.Errorf("parsing docker-compose port output %q: %w", firstLine, err)
+	}
+
+	return PublishedPort{
+		Host: normalizePublishedHost(host),
+		Port: port,
+	}, nil
+}
+
+func normalizePublishedHost(host string) string {
+	switch host {
+	case "", "0.0.0.0", "::":
+		return "localhost"
+	default:
+		return host
+	}
 }

--- a/internal/infra/docker_test.go
+++ b/internal/infra/docker_test.go
@@ -1,0 +1,21 @@
+package infra
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePublishedPort(t *testing.T) {
+	published, err := parsePublishedPort([]byte("127.0.0.1:9100\n"))
+
+	require.NoError(t, err)
+	require.Equal(t, PublishedPort{Host: "127.0.0.1", Port: "9100"}, published)
+}
+
+func TestParsePublishedPortNormalizesWildcardHost(t *testing.T) {
+	published, err := parsePublishedPort([]byte("0.0.0.0:9100\n"))
+
+	require.NoError(t, err)
+	require.Equal(t, PublishedPort{Host: "localhost", Port: "9100"}, published)
+}

--- a/internal/testing/config.go
+++ b/internal/testing/config.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	appconfig "github.com/ethpandaops/xatu-cbt/internal/config"
 )
 
 // TestConfig holds test execution operational parameters.
@@ -59,7 +61,7 @@ func DefaultTestConfig() *TestConfig {
 	return &TestConfig{
 		// Docker
 		DockerImage:   "ethpandaops/cbt:debian-latest",
-		DockerNetwork: "xatu_xatu-net",
+		DockerNetwork: appconfig.GetDockerNetworkName(),
 
 		// Execution timeouts
 		ExecutionTimeout:          30 * time.Minute,

--- a/internal/testing/docker.go
+++ b/internal/testing/docker.go
@@ -1,0 +1,17 @@
+package testing
+
+import "github.com/ethpandaops/xatu-cbt/internal/config"
+
+func redisComposeArgs(redisCLIArgs ...string) []string {
+	args := []string{
+		"compose",
+		"-f", config.PlatformComposeFile,
+		"-p", config.GetProjectName(),
+		"exec",
+		"-T",
+		config.RedisContainerName,
+		"redis-cli",
+	}
+
+	return append(args, redisCLIArgs...)
+}

--- a/internal/testing/engine.go
+++ b/internal/testing/engine.go
@@ -166,7 +166,7 @@ func (e *CBTEngine) flushRedisDB(ctx context.Context, dbNum int) error {
 	// Use redis-cli -n to select the DB, then FLUSHDB to clear it.
 	// dbNum is from a controlled pool (1-15), not user input.
 	dbNumStr := fmt.Sprintf("%d", dbNum)
-	args := []string{"exec", config.RedisContainerName, "redis-cli", "-n", dbNumStr, "FLUSHDB"}
+	args := redisComposeArgs("-n", dbNumStr, "FLUSHDB")
 
 	cmd := exec.CommandContext(ctx, "docker", args...) //nolint:gosec // G204: args are from trusted internal pool
 

--- a/internal/testing/orchestrator.go
+++ b/internal/testing/orchestrator.go
@@ -11,7 +11,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ethpandaops/xatu-cbt/internal/config"
 	"github.com/ethpandaops/xatu-cbt/internal/testing/assertion"
 	"github.com/ethpandaops/xatu-cbt/internal/testing/output"
 	"github.com/ethpandaops/xatu-cbt/internal/testing/testdef"
@@ -215,9 +214,8 @@ func (o *Orchestrator) Stop() error {
 
 	var errs []error
 
-	// Flush Redis cache once at shutdown
-	//nolint:gosec // G204: Docker command with trusted container name
-	flushCmd := exec.Command("docker", "exec", config.RedisContainerName, "redis-cli", "FLUSHALL")
+	// Flush Redis cache once at shutdown.
+	flushCmd := exec.Command("docker", redisComposeArgs("FLUSHALL")...) //nolint:gosec // G204: Docker command with controlled arguments.
 	if err := flushCmd.Run(); err != nil {
 		o.log.WithError(err).Warn("failed to flush redis cache")
 		errs = append(errs, fmt.Errorf("flushing redis: %w", err))
@@ -891,9 +889,7 @@ func (o *Orchestrator) ensureTemplatesPrepared(ctx context.Context, network stri
 
 // flushRedisCache clears Redis cache to prevent stale cached values.
 func (o *Orchestrator) flushRedisCache(ctx context.Context) error {
-	// Use docker exec to flush Redis database
-	//nolint:gosec // G204: Docker command with trusted container name.
-	cmd := exec.CommandContext(ctx, "docker", "exec", config.RedisContainerName, "redis-cli", "FLUSHDB")
+	cmd := exec.CommandContext(ctx, "docker", redisComposeArgs("FLUSHDB")...) //nolint:gosec // G204: Docker command with controlled arguments.
 	if cmdOutput, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("flushing redis: %w (output: %s)", err, string(cmdOutput))
 	}


### PR DESCRIPTION
Adds an optional `--project-name` flag (env fallback `XATU_CBT_PROJECT_NAME`) to `infra start|stop|reset|migrate-xatu` so multiple isolated ClickHouse/Redis stacks can run concurrently on one host — the companion change that lets xcli run multiple lab stacks side by side from different worktrees. Container/volume/network names now derive uniformly from the compose project name, host ports come from the existing `CLICKHOUSE_*_PORT`/`REDIS_PORT` env overrides (defaults unchanged), and migration targeting resolves the actual published port of the selected project so an isolated stack's migrations hit that stack.

Breaking (hard cutover): explicit `container_name:`/volume `name:` pins are removed in favour of Compose-native `<project>-<service>` names, so any existing stack must be torn down once (`infra stop` / `docker rm`) before upgrading — old containers won't be adopted under the new names.