### PR TITLE
fix(fct_engine_new_payload_by_el_client_hourly): aggregate over complete hours

### DIFF
--- a/models/transformations/fct_engine_new_payload_by_el_client_hourly.sql
+++ b/models/transformations/fct_engine_new_payload_by_el_client_hourly.sql
@@ -33,9 +33,8 @@ block_context AS (
         slot_start_date_time,
         execution_payload_block_hash
     FROM {{ index .dep "{{transformation}}" "fct_block_head" "helpers" "from" }} FINAL
-    -- Use wider window to ensure we catch all blocks that might match engine events
-    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 5 MINUTE
-        AND fromUnixTimestamp({{ .bounds.end }}) + INTERVAL 5 MINUTE
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 65 MINUTE
+        AND fromUnixTimestamp({{ .bounds.end }}) + INTERVAL 65 MINUTE
         AND execution_payload_block_hash IS NOT NULL AND execution_payload_block_hash != ''
 ),
 -- Fetch external data separately to avoid cross-cluster join pushdown issues
@@ -54,8 +53,8 @@ engine_payloads AS (
     FROM {{ index .dep "{{external}}" "execution_engine_new_payload" "helpers" "from" }} FINAL
     WHERE meta_network_name = '{{ .env.NETWORK }}'
         AND meta_execution_implementation != ''
-        AND event_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 1 MINUTE
-            AND fromUnixTimestamp({{ .bounds.end }}) + INTERVAL 1 MINUTE
+        AND event_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 65 MINUTE
+            AND fromUnixTimestamp({{ .bounds.end }}) + INTERVAL 65 MINUTE
 ),
 -- Join execution engine data with slot context locally
 enriched AS (
@@ -78,13 +77,14 @@ enriched AS (
     FROM engine_payloads ep
     GLOBAL LEFT JOIN block_context bc ON ep.block_hash = bc.execution_payload_block_hash
 ),
--- Find the hour boundaries from the enriched data
+-- Find the hour boundaries from the enriched data within the current bounds
 hour_bounds AS (
     SELECT
         toStartOfHour(min(slot_start_date_time)) AS min_hour,
         toStartOfHour(max(slot_start_date_time)) AS max_hour
     FROM enriched
     WHERE slot_start_date_time != toDateTime(0)
+        AND slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
 ),
 -- Filter to complete hour boundaries
 events_in_hours AS (


### PR DESCRIPTION
The model reads its source with a `bounds ± 1 MINUTE` window and derives `hour_bounds` from that same clipped set, so the expansion to complete hour boundaries described in its header comment never happens — each incremental task (24-36s of slot time) writes a full hour row aggregated over only its own 2-3 slots, and the ReplacingMergeTree keeps whichever wrote last. Mainnet hours hold ~2 observations instead of ~4300, which makes `p50_duration_ms` sampling noise and leaves `p95_duration_ms` 25-40% below the real tail. Widening both source windows to `± 65 MINUTE` and scoping `hour_bounds` to slots inside the task bounds brings this in line with `fct_engine_get_blobs_by_el_client_hourly`, which already reads this way and does not have the defect.

Replaying old vs new task logic against live mainnet data for a 12s task landing mid-hour, Besu / `eip7870-block-builder`: current writes 22 observations over 11 slots (p50 104, p95 134), this PR writes 598 over 299 slots (p50 106, p95 224), and the whole hour truly holds 598 over 299 slots (p50 106, p95 224). The model test passes 10/10 with output unchanged, since its fixture is a single 25-slot hour consumed by one task — the harness structurally cannot reach a bug that only appears across many small incremental tasks.

Rows already written stay wrong: the model needs its coverage reset to reprocess, otherwise only hours built after this deploys will be correct.