### PR TITLE
feat(engine_new_payload): keep tied winners per implementation

### DIFF
--- a/migrations/100_engine_new_payload_tie_winners.down.sql
+++ b/migrations/100_engine_new_payload_tie_winners.down.sql
@@ -1,0 +1,41 @@
+-- Restore the single-winner schema from migration 068.
+DROP TABLE IF EXISTS int_engine_new_payload_fastest_execution_by_node_class ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS int_engine_new_payload_fastest_execution_by_node_class_local ON CLUSTER '{cluster}' SYNC;
+
+CREATE TABLE int_engine_new_payload_fastest_execution_by_node_class_local ON CLUSTER '{cluster}' (
+    `updated_date_time` DateTime COMMENT 'Timestamp when the record was last updated' CODEC(DoubleDelta, ZSTD(1)),
+    `slot` UInt32 COMMENT 'Slot number of the beacon block containing the payload' CODEC(DoubleDelta, ZSTD(1)),
+    `slot_start_date_time` DateTime COMMENT 'The wall clock time when the slot started' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch` UInt32 COMMENT 'Epoch number derived from the slot' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch_start_date_time` DateTime COMMENT 'The wall clock time when the epoch started' CODEC(DoubleDelta, ZSTD(1)),
+    `block_hash` FixedString(66) COMMENT 'Execution block hash (hex encoded with 0x prefix)' CODEC(ZSTD(1)),
+    `duration_ms` UInt64 COMMENT 'Duration of the fastest engine_newPayload call in milliseconds' CODEC(ZSTD(1)),
+    `node_class` LowCardinality(String) COMMENT 'Node classification for grouping observations (e.g., eip7870-block-builder, or empty for general nodes)' CODEC(ZSTD(1)),
+    `meta_execution_implementation` LowCardinality(String) COMMENT 'Execution client implementation name (e.g., Geth, Nethermind, Besu, Reth)' CODEC(ZSTD(1)),
+    `meta_execution_version` LowCardinality(String) COMMENT 'Full execution client version string from web3_clientVersion RPC' CODEC(ZSTD(1)),
+    `meta_client_name` LowCardinality(String) COMMENT 'Name of the client that generated the event' CODEC(ZSTD(1))
+) ENGINE = ReplicatedReplacingMergeTree(
+    '/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}',
+    '{replica}',
+    `updated_date_time`
+) PARTITION BY toStartOfMonth(slot_start_date_time)
+ORDER BY (slot_start_date_time, slot, node_class)
+COMMENT 'Fastest valid engine_newPayload observation per slot per node_class';
+
+CREATE TABLE int_engine_new_payload_fastest_execution_by_node_class ON CLUSTER '{cluster}'
+AS int_engine_new_payload_fastest_execution_by_node_class_local
+ENGINE = Distributed(
+    '{cluster}',
+    currentDatabase(),
+    int_engine_new_payload_fastest_execution_by_node_class_local,
+    cityHash64(slot_start_date_time, slot, node_class)
+);
+
+-- Reset CBT processing positions so the recreated table and its winrate
+-- aggregations rebuild with single winners.
+ALTER TABLE admin_cbt_incremental_local ON CLUSTER '{cluster}'
+DELETE WHERE `table` IN (
+    'int_engine_new_payload_fastest_execution_by_node_class',
+    'fct_engine_new_payload_winrate_hourly',
+    'fct_engine_new_payload_winrate_daily'
+) SETTINGS mutations_sync = 2;

--- a/migrations/100_engine_new_payload_tie_winners.up.sql
+++ b/migrations/100_engine_new_payload_tie_winners.up.sql
@@ -1,0 +1,43 @@
+-- Recreate int_engine_new_payload_fastest_execution_by_node_class with
+-- meta_execution_implementation in the sorting key so tied winners survive
+-- ReplacingMergeTree merges (one row per implementation at the slot minimum).
+DROP TABLE IF EXISTS int_engine_new_payload_fastest_execution_by_node_class ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS int_engine_new_payload_fastest_execution_by_node_class_local ON CLUSTER '{cluster}' SYNC;
+
+CREATE TABLE int_engine_new_payload_fastest_execution_by_node_class_local ON CLUSTER '{cluster}' (
+    `updated_date_time` DateTime COMMENT 'Timestamp when the record was last updated' CODEC(DoubleDelta, ZSTD(1)),
+    `slot` UInt32 COMMENT 'Slot number of the beacon block containing the payload' CODEC(DoubleDelta, ZSTD(1)),
+    `slot_start_date_time` DateTime COMMENT 'The wall clock time when the slot started' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch` UInt32 COMMENT 'Epoch number derived from the slot' CODEC(DoubleDelta, ZSTD(1)),
+    `epoch_start_date_time` DateTime COMMENT 'The wall clock time when the epoch started' CODEC(DoubleDelta, ZSTD(1)),
+    `block_hash` FixedString(66) COMMENT 'Execution block hash (hex encoded with 0x prefix)' CODEC(ZSTD(1)),
+    `duration_ms` UInt64 COMMENT 'Duration of the fastest engine_newPayload call in milliseconds' CODEC(ZSTD(1)),
+    `node_class` LowCardinality(String) COMMENT 'Node classification for grouping observations (e.g., eip7870-block-builder, or empty for general nodes)' CODEC(ZSTD(1)),
+    `meta_execution_implementation` LowCardinality(String) COMMENT 'Execution client implementation name (e.g., Geth, Nethermind, Besu, Reth)' CODEC(ZSTD(1)),
+    `meta_execution_version` LowCardinality(String) COMMENT 'Full execution client version string from web3_clientVersion RPC' CODEC(ZSTD(1)),
+    `meta_client_name` LowCardinality(String) COMMENT 'Name of the client that generated the event' CODEC(ZSTD(1))
+) ENGINE = ReplicatedReplacingMergeTree(
+    '/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}',
+    '{replica}',
+    `updated_date_time`
+) PARTITION BY toStartOfMonth(slot_start_date_time)
+ORDER BY (slot_start_date_time, slot, node_class, meta_execution_implementation)
+COMMENT 'Fastest valid engine_newPayload observations per slot per node_class with one row per implementation tied at the minimum duration';
+
+CREATE TABLE int_engine_new_payload_fastest_execution_by_node_class ON CLUSTER '{cluster}'
+AS int_engine_new_payload_fastest_execution_by_node_class_local
+ENGINE = Distributed(
+    '{cluster}',
+    currentDatabase(),
+    int_engine_new_payload_fastest_execution_by_node_class_local,
+    cityHash64(slot_start_date_time, slot, node_class)
+);
+
+-- Reset CBT processing positions so the recreated table and its winrate
+-- aggregations rebuild with tie-aware winners.
+ALTER TABLE admin_cbt_incremental_local ON CLUSTER '{cluster}'
+DELETE WHERE `table` IN (
+    'int_engine_new_payload_fastest_execution_by_node_class',
+    'fct_engine_new_payload_winrate_hourly',
+    'fct_engine_new_payload_winrate_daily'
+) SETTINGS mutations_sync = 2;

--- a/models/transformations/int_engine_new_payload_fastest_execution_by_node_class.sql
+++ b/models/transformations/int_engine_new_payload_fastest_execution_by_node_class.sql
@@ -14,6 +14,8 @@ dependencies:
   - "{{transformation}}.int_engine_new_payload"
 ---
 -- Fastest valid engine_newPayload observation per slot per node_class.
+-- Ties produce one row per implementation matching the slot minimum, with a
+-- deterministic representative node per implementation.
 -- Filters for VALID status and known execution implementation (data quality).
 -- Does NOT filter by node_class — all classes are carried through as a dimension.
 INSERT INTO `{{ .self.database }}`.`{{ .self.table }}`
@@ -30,7 +32,11 @@ ranked AS (
         meta_execution_implementation,
         meta_execution_version,
         meta_client_name,
-        ROW_NUMBER() OVER (PARTITION BY slot, node_class ORDER BY duration_ms ASC) AS rn
+        MIN(duration_ms) OVER (PARTITION BY slot, node_class) AS min_duration_ms,
+        ROW_NUMBER() OVER (
+            PARTITION BY slot, node_class, meta_execution_implementation
+            ORDER BY duration_ms ASC, meta_client_name ASC
+        ) AS rn
     FROM {{ index .dep "{{transformation}}" "int_engine_new_payload" "helpers" "from" }} FINAL
     WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
         AND status = 'VALID'
@@ -49,4 +55,4 @@ SELECT
     meta_execution_version,
     meta_client_name
 FROM ranked
-WHERE rn = 1
+WHERE rn = 1 AND duration_ms = min_duration_ms

--- a/tests/mainnet/models/fct_engine_new_payload_winrate_daily.yaml
+++ b/tests/mainnet/models/fct_engine_new_payload_winrate_daily.yaml
@@ -69,15 +69,17 @@ assertions:
         - type: equals
           column: count
           value: 0
-    - name: Total win_count per day per node_class should not exceed slot count for that day
+    - name: win_count per implementation should not exceed distinct slots observed for that day and node_class
       sql: |
-        SELECT COUNT(*) AS count FROM (
-          SELECT day_start_date, node_class, COALESCE(SUM(win_count), 0) AS total_wins
-          FROM fct_engine_new_payload_winrate_daily FINAL
+        SELECT COUNT(*) AS violation_count
+        FROM fct_engine_new_payload_winrate_daily AS w FINAL
+        GLOBAL INNER JOIN (
+          SELECT toDate(slot_start_date_time) AS day_start_date, node_class, uniqExact(slot) AS slot_count
+          FROM int_engine_new_payload_fastest_execution_by_node_class FINAL
           GROUP BY day_start_date, node_class
-          HAVING total_wins > 7200
-        )
+        ) AS s ON w.day_start_date = s.day_start_date AND w.node_class = s.node_class
+        WHERE w.win_count > s.slot_count
       assertions:
         - type: equals
-          column: count
+          column: violation_count
           value: 0

--- a/tests/mainnet/models/fct_engine_new_payload_winrate_hourly.yaml
+++ b/tests/mainnet/models/fct_engine_new_payload_winrate_hourly.yaml
@@ -55,16 +55,13 @@ assertions:
         - type: equals
           column: count
           value: 0
-    - name: Sum of win_count per hour per node_class should not exceed slots in an hour (3600/12 = 300)
+    - name: win_count per implementation should not exceed slots in an hour (3600/12 = 300)
       sql: |
-        SELECT COALESCE(MAX(total_wins), 0) AS max_wins_per_hour FROM (
-          SELECT hour_start_date_time, node_class, SUM(win_count) AS total_wins
-          FROM fct_engine_new_payload_winrate_hourly FINAL
-          GROUP BY hour_start_date_time, node_class
-        )
+        SELECT COALESCE(MAX(win_count), 0) AS max_win_count
+        FROM fct_engine_new_payload_winrate_hourly FINAL
       assertions:
         - type: less_than_or_equal
-          column: max_wins_per_hour
+          column: max_win_count
           value: 300
     - name: hour_start_date_time should not be in the future
       sql: |

--- a/tests/mainnet/models/fct_engine_new_payload_winrate_hourly.yaml
+++ b/tests/mainnet/models/fct_engine_new_payload_winrate_hourly.yaml
@@ -55,14 +55,20 @@ assertions:
         - type: equals
           column: count
           value: 0
-    - name: win_count per implementation should not exceed slots in an hour (3600/12 = 300)
+    - name: win_count per implementation should not exceed distinct slots observed for that hour and node_class
       sql: |
-        SELECT COALESCE(MAX(win_count), 0) AS max_win_count
-        FROM fct_engine_new_payload_winrate_hourly FINAL
+        SELECT COUNT(*) AS violation_count
+        FROM fct_engine_new_payload_winrate_hourly AS w FINAL
+        GLOBAL INNER JOIN (
+          SELECT toStartOfHour(slot_start_date_time) AS hour_start_date_time, node_class, uniqExact(slot) AS slot_count
+          FROM int_engine_new_payload_fastest_execution_by_node_class FINAL
+          GROUP BY hour_start_date_time, node_class
+        ) AS s ON w.hour_start_date_time = s.hour_start_date_time AND w.node_class = s.node_class
+        WHERE w.win_count > s.slot_count
       assertions:
-        - type: less_than_or_equal
-          column: max_win_count
-          value: 300
+        - type: equals
+          column: violation_count
+          value: 0
     - name: hour_start_date_time should not be in the future
       sql: |
         SELECT COUNT(*) AS count FROM fct_engine_new_payload_winrate_hourly FINAL WHERE hour_start_date_time > now()

--- a/tests/mainnet/models/int_engine_new_payload_fastest_execution_by_node_class.yaml
+++ b/tests/mainnet/models/int_engine_new_payload_fastest_execution_by_node_class.yaml
@@ -15,18 +15,31 @@ assertions:
         - type: greater_than
           column: count
           value: 0
-    - name: Each slot and node_class pair should be unique (fastest only)
+    - name: Each slot, node_class and implementation combination should be unique
       sql: |
         SELECT COUNT(*) AS duplicate_count
         FROM (
-            SELECT slot, node_class, COUNT(*) AS cnt
+            SELECT slot, node_class, meta_execution_implementation, COUNT(*) AS cnt
             FROM int_engine_new_payload_fastest_execution_by_node_class FINAL
-            GROUP BY slot, node_class
+            GROUP BY slot, node_class, meta_execution_implementation
             HAVING cnt > 1
         )
       assertions:
         - type: equals
           column: duplicate_count
+          value: 0
+    - name: All winners for a slot and node_class should share the minimum duration
+      sql: |
+        SELECT COUNT(*) AS mixed_duration_count
+        FROM (
+            SELECT slot, node_class
+            FROM int_engine_new_payload_fastest_execution_by_node_class FINAL
+            GROUP BY slot, node_class
+            HAVING uniqExact(duration_ms) > 1
+        )
+      assertions:
+        - type: equals
+          column: mixed_duration_count
           value: 0
     - name: duration_ms should be non-negative
       sql: |


### PR DESCRIPTION
Slots where multiple implementations tie on minimum duration_ms (~13% of mainnet slots for 7870 nodes) previously crowned one arbitrary winner via ROW_NUMBER with no secondary sort key. Now int_engine_new_payload_fastest_execution_by_node_class keeps one row per implementation matching the slot minimum, so the winrate models credit every tied client fully; migration 100 recreates the table with meta_execution_implementation in the sorting key and resets CBT positions so history rebuilds tie-aware. Lab needs no changes — both winrate paths already normalise by total wins.