### PR TITLE
chore(engine_new_payload): temporarily crank backfill for tie-aware rebuild

### DIFF
--- a/models/transformations/fct_engine_new_payload_winrate_daily.sql
+++ b/models/transformations/fct_engine_new_payload_winrate_daily.sql
@@ -6,7 +6,7 @@ interval:
   max: 604800
 schedules:
   forwardfill: "@every 1h"
-  backfill: "@every 30s"
+  backfill: "@every 5s"
 tags:
   - daily
   - execution

--- a/models/transformations/fct_engine_new_payload_winrate_hourly.sql
+++ b/models/transformations/fct_engine_new_payload_winrate_hourly.sql
@@ -3,10 +3,10 @@ table: fct_engine_new_payload_winrate_hourly
 type: incremental
 interval:
   type: slot
-  max: 25200
+  max: 172800
 schedules:
   forwardfill: "@every 5m"
-  backfill: "@every 30s"
+  backfill: "@every 5s"
 tags:
   - hourly
   - execution

--- a/models/transformations/int_engine_new_payload_fastest_execution_by_node_class.sql
+++ b/models/transformations/int_engine_new_payload_fastest_execution_by_node_class.sql
@@ -3,10 +3,10 @@ table: int_engine_new_payload_fastest_execution_by_node_class
 type: incremental
 interval:
   type: slot
-  max: 50000
+  max: 200000
 schedules:
   forwardfill: "@every 5s"
-  backfill: "@every 30s"
+  backfill: "@every 5s"
 tags:
   - slot
   - engine


### PR DESCRIPTION
Temporary: larger chunks + 5s backfill cadence for int_engine_new_payload_fastest_execution_by_node_class and the winrate hourly/daily models so the post-migration-100 history rebuild completes in minutes instead of hours. Will be reverted once mainnet catches up to 2026-03-27.