### PR TITLE
proposal(fct_block_proposer_head): OR-group block sources to extend history (~2023-03, not merge-ready)

### DIFF
--- a/models/transformations/fct_block_proposer_head.sql
+++ b/models/transformations/fct_block_proposer_head.sql
@@ -13,11 +13,11 @@ tags:
   - proposer
   - head
 dependencies:
-  - "{{external}}.beacon_api_eth_v1_events_block_gossip"
-  - "{{external}}.beacon_api_eth_v1_events_block"
+  - - "{{external}}.beacon_api_eth_v1_events_block_gossip"
+    - "{{external}}.beacon_api_eth_v1_events_block"
+    - "{{external}}.libp2p_gossipsub_beacon_block"
   - - "{{external}}.beacon_api_eth_v1_proposer_duty"
     - "{{external}}.canonical_beacon_proposer_duty"
-  - "{{external}}.libp2p_gossipsub_beacon_block"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`
@@ -117,6 +117,14 @@ gate AS (
         ) - toInt64((SELECT count() FROM duty_slots)) AS missing_slots
 ),
 
+-- The three block-observation sources below (gossip event, block event, and
+-- libp2p gossipsub) redundantly report the same block root per slot, so they
+-- form an OR-group dependency: any one is sufficient and they are unioned and
+-- deduplicated in all_blocks. Grouping them keeps the model's range floor at
+-- the earliest source (events/gossipsub reach genesis) rather than pinning it
+-- to the gossip event stream, which only begins once a network has live
+-- collection. Where a source has no data for the interval its CTE is simply
+-- empty and contributes nothing.
 block_gossip AS (
     SELECT DISTINCT
         slot,


### PR DESCRIPTION
**Proposal, not merge-ready — read the blocker.**

`fct_block_proposer_head` reads three redundant block-observation sources (gossip event, block event, libp2p gossipsub) but declares them as plain AND dependencies, so `beacon_api_eth_v1_events_block_gossip` — which only starts once a network has live collection (2025-05-14 on mainnet) — pins the model's backfill floor to 2025-05-14. OR-grouping the three makes the floor the earliest member instead of the latest (confirmed against the engine: an OR-group's range is `MIN(members)`), mirroring the existing proposer-duty OR-group.

**How far this actually reaches:** `beacon_api_eth_v1_events_block` has continuous data from **2023-03**, `libp2p_gossipsub_beacon_block` from 2024-05, `block_gossip` from 2025-05. So the real floor this unlocks is **~2023-03, not genesis** — a ~2-year gain for `fct_block_proposer` → `fct_reorg` / `fct_missed_slot_rate` / `fct_block_proposal_status` / `fct_attestation_inclusion_delay`. These metrics need head-time block observation (to distinguish orphaned/reorged from missed), which does not exist before live collection, so 2023-03 is a physical floor, not a modelling choice. (The canonical-sourced sections — attestation participation, head-vote correctness — already reach genesis and are unaffected by this.)

**Blocker (why this must not be merged alone):** `beacon_api_eth_v1_events_block` and `libp2p_gossipsub_beacon_block` each carry a few stray pre-collection rows — 8,800 and 4 rows in Dec 2020 respectively, then zero until real collection begins. Production runs `EXTERNAL_MODEL_MIN_TIMESTAMP=0`, so CBT's external `min(position)` reads those stray rows as genesis. With this change the floor would drop to genesis and backfill 2020-12 → 2023-03 with no block data at all, writing every slot as "missed" — garbage that then propagates downstream. This change only becomes safe once those stray rows are excluded for the two block sources specifically. The global `EXTERNAL_MODEL_MIN_TIMESTAMP` is not a safe lever, because the canonical sources genuinely reach genesis and must not be floored.

One further semantics note for whoever picks this up: forward-fill uses union bounds, so at the head the model would advance to the fastest of the three block sources rather than waiting for the slowest. That is safe in practice (the proposer-duty completeness gate with its 1h settling window is the binding head constraint, and block roots are deterministic content), but it is a behavior change worth a conscious sign-off.