### PR TITLE
feat(fct_missed_slot_rate): source from canonical chain to reach genesis

### DIFF
--- a/models/transformations/fct_missed_slot_rate_daily.sql
+++ b/models/transformations/fct_missed_slot_rate_daily.sql
@@ -12,17 +12,22 @@ tags:
   - consensus
   - missed
 dependencies:
-  - "{{transformation}}.fct_block_proposer"
+  - "{{transformation}}.int_block_proposer_canonical"
 ---
 -- Daily aggregation of missed slot rate.
 -- Computes the percentage of missed slots per day with a 7-day moving average.
+-- A missed slot is any slot with no block in the canonical chain (block_root
+-- IS NULL). Sourced from int_block_proposer_canonical rather than the head path
+-- so the metric reaches genesis. The trade-off is that orphaned slots (a block
+-- was proposed but reorged out, leaving no canonical block) count as missed,
+-- because distinguishing orphaned from missed requires head-time observation.
 INSERT INTO `{{ .self.database }}`.`{{ .self.table }}`
 WITH
     day_bounds AS (
         SELECT
             toDate(min(slot_start_date_time)) AS min_day,
             toDate(max(slot_start_date_time)) AS max_day
-        FROM {{ index .dep "{{transformation}}" "fct_block_proposer" "helpers" "from" }} FINAL
+        FROM {{ index .dep "{{transformation}}" "int_block_proposer_canonical" "helpers" "from" }} FINAL
         WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
     ),
     slots_in_days AS (
@@ -30,8 +35,8 @@ WITH
             slot,
             slot_start_date_time,
             toUnixTimestamp(slot_start_date_time) AS slot_timestamp,
-            if(status = 'missed', 1, 0) AS is_missed
-        FROM {{ index .dep "{{transformation}}" "fct_block_proposer" "helpers" "from" }} FINAL
+            if(block_root IS NULL, 1, 0) AS is_missed
+        FROM {{ index .dep "{{transformation}}" "int_block_proposer_canonical" "helpers" "from" }} FINAL
         WHERE toDate(slot_start_date_time) >= (SELECT min_day FROM day_bounds)
           AND toDate(slot_start_date_time) <= (SELECT max_day FROM day_bounds)
     ),

--- a/models/transformations/fct_missed_slot_rate_hourly.sql
+++ b/models/transformations/fct_missed_slot_rate_hourly.sql
@@ -12,18 +12,22 @@ tags:
   - consensus
   - missed
 dependencies:
-  - "{{transformation}}.fct_block_proposer"
+  - "{{transformation}}.int_block_proposer_canonical"
 ---
 -- Hourly aggregation of missed slot rate.
 -- Computes the percentage of missed slots per hour with a 6-hour moving average.
--- Source: fct_block_proposer (status = 'missed' indicates no block was produced).
+-- A missed slot is any slot with no block in the canonical chain (block_root
+-- IS NULL). Sourced from int_block_proposer_canonical rather than the head path
+-- so the metric reaches genesis. The trade-off is that orphaned slots (a block
+-- was proposed but reorged out, leaving no canonical block) count as missed,
+-- because distinguishing orphaned from missed requires head-time observation.
 INSERT INTO `{{ .self.database }}`.`{{ .self.table }}`
 WITH
     hour_bounds AS (
         SELECT
             toStartOfHour(min(slot_start_date_time)) AS min_hour,
             toStartOfHour(max(slot_start_date_time)) AS max_hour
-        FROM {{ index .dep "{{transformation}}" "fct_block_proposer" "helpers" "from" }} FINAL
+        FROM {{ index .dep "{{transformation}}" "int_block_proposer_canonical" "helpers" "from" }} FINAL
         WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
     ),
     slots_in_hours AS (
@@ -31,8 +35,8 @@ WITH
             slot,
             slot_start_date_time,
             toUnixTimestamp(slot_start_date_time) AS slot_timestamp,
-            if(status = 'missed', 1, 0) AS is_missed
-        FROM {{ index .dep "{{transformation}}" "fct_block_proposer" "helpers" "from" }} FINAL
+            if(block_root IS NULL, 1, 0) AS is_missed
+        FROM {{ index .dep "{{transformation}}" "int_block_proposer_canonical" "helpers" "from" }} FINAL
         WHERE slot_start_date_time >= (SELECT min_hour FROM hour_bounds)
           AND slot_start_date_time < (SELECT max_hour FROM hour_bounds) + INTERVAL 1 HOUR
     ),

--- a/tests/mainnet/models/fct_missed_slot_rate_daily.yaml
+++ b/tests/mainnet/models/fct_missed_slot_rate_daily.yaml
@@ -1,23 +1,11 @@
 model: fct_missed_slot_rate_daily
 network: mainnet
 external_data:
-    beacon_api_eth_v1_events_block:
-        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_missed_slot_rate_daily_beacon_api_eth_v1_events_block.parquet
-        network_column: meta_network_name
-    beacon_api_eth_v1_events_block_gossip:
-        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_missed_slot_rate_daily_beacon_api_eth_v1_events_block_gossip.parquet
-        network_column: meta_network_name
-    beacon_api_eth_v1_proposer_duty:
-        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_missed_slot_rate_daily_beacon_api_eth_v1_proposer_duty.parquet
-        network_column: meta_network_name
     canonical_beacon_block:
         url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_missed_slot_rate_daily_canonical_beacon_block.parquet
         network_column: meta_network_name
     canonical_beacon_proposer_duty:
         url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_missed_slot_rate_daily_canonical_beacon_proposer_duty.parquet
-        network_column: meta_network_name
-    libp2p_gossipsub_beacon_block:
-        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_missed_slot_rate_daily_libp2p_gossipsub_beacon_block.parquet
         network_column: meta_network_name
 assertions:
     - name: Row count should be greater than zero

--- a/tests/mainnet/models/fct_missed_slot_rate_hourly.yaml
+++ b/tests/mainnet/models/fct_missed_slot_rate_hourly.yaml
@@ -1,23 +1,11 @@
 model: fct_missed_slot_rate_hourly
 network: mainnet
 external_data:
-    beacon_api_eth_v1_events_block:
-        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_missed_slot_rate_hourly_beacon_api_eth_v1_events_block.parquet
-        network_column: meta_network_name
-    beacon_api_eth_v1_events_block_gossip:
-        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_missed_slot_rate_hourly_beacon_api_eth_v1_events_block_gossip.parquet
-        network_column: meta_network_name
-    beacon_api_eth_v1_proposer_duty:
-        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_missed_slot_rate_hourly_beacon_api_eth_v1_proposer_duty.parquet
-        network_column: meta_network_name
     canonical_beacon_block:
         url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_missed_slot_rate_hourly_canonical_beacon_block.parquet
         network_column: meta_network_name
     canonical_beacon_proposer_duty:
         url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_missed_slot_rate_hourly_canonical_beacon_proposer_duty.parquet
-        network_column: meta_network_name
-    libp2p_gossipsub_beacon_block:
-        url: https://data.ethpandaops.io/xatu-cbt/tests/mainnet/fct_missed_slot_rate_hourly_libp2p_gossipsub_beacon_block.parquet
         network_column: meta_network_name
 assertions:
     - name: Row count should be greater than zero


### PR DESCRIPTION
`fct_missed_slot_rate_{hourly,daily}` depended on `fct_block_proposer`, which is capped at 2025-05-14 on mainnet because it merges in the head-observation path (`fct_block_proposer_head`). A missed slot doesn't need head data though — `int_block_proposer_canonical` (genesis→now) already carries `block_root` per slot, NULL when no canonical block exists. This re-sources both models from `int_block_proposer_canonical` and defines missed as `block_root IS NULL`, so the metric reaches genesis instead of starting mid-2025.

Verified against production: on an overlapping recent month `block_root IS NULL` equals `status IN ('missed','orphaned')` exactly (0.514% for 2025-08) versus the old `status='missed'` (0.348%), and historical values are sane (~0.9% for 2022). The consequence is a small, deliberate definition change: the series now counts orphaned slots (a block was proposed but reorged out, leaving no canonical block) as missed. That orphaned-vs-missed split needs head-time observation and cannot be reconstructed before live collection existed, so folding it in is the only way to extend the series to genesis — and "slots with no canonical block" is a standard missed-slot definition. Test fixtures are trimmed to the new canonical-only dependency closure.

This is independent of and complementary to #294: it does not touch the head path, so it carries none of that PR's stray-row backfill risk. Reorgs and the orphaned/missed split in block proposal status still genuinely require head data; attestation inclusion delay is also canonical-derivable but routes through a shared intermediate and needs a more careful refactor.