### PR TITLE
fix(models): OR-group libp2p gossip dep; publish release/** images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+      # Per-devnet release branches (e.g. release/glamsterdam-devnet-7) publish
+      # persistent branch-ref tags like release-glamsterdam-devnet-7 so devnet
+      # deployments can pin models that must not ship to mainnet yet.
+      - 'release/**'
   workflow_dispatch:
     inputs:
       cbt_tag:

--- a/models/transformations/fct_block_first_seen_by_node.sql
+++ b/models/transformations/fct_block_first_seen_by_node.sql
@@ -45,7 +45,7 @@ WITH combined_events AS (
         meta_consensus_version,
         meta_consensus_implementation
     FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_events_block" "helpers" "from" }} FINAL
-    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 90 SECOND AND fromUnixTimestamp({{ .bounds.end }})
         AND meta_network_name = '{{ .env.NETWORK }}'
     
     UNION ALL
@@ -72,7 +72,7 @@ WITH combined_events AS (
         meta_consensus_version,
         meta_consensus_implementation
     FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_events_block_gossip" "helpers" "from" }} FINAL
-    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 90 SECOND AND fromUnixTimestamp({{ .bounds.end }})
         AND meta_network_name = '{{ .env.NETWORK }}'
     
     UNION ALL
@@ -99,7 +99,7 @@ WITH combined_events AS (
         meta_consensus_version,
         meta_consensus_implementation
     FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_events_head" "helpers" "from" }} FINAL
-    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 90 SECOND AND fromUnixTimestamp({{ .bounds.end }})
         AND meta_network_name = '{{ .env.NETWORK }}'
     
     UNION ALL
@@ -135,7 +135,7 @@ WITH combined_events AS (
                 ''
         END AS meta_consensus_implementation
     FROM {{ index .dep "{{external}}" "libp2p_gossipsub_beacon_block" "helpers" "from" }} FINAL
-    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 90 SECOND AND fromUnixTimestamp({{ .bounds.end }})
         AND meta_network_name = '{{ .env.NETWORK }}'
 )
 SELECT

--- a/models/transformations/fct_block_first_seen_by_node.sql
+++ b/models/transformations/fct_block_first_seen_by_node.sql
@@ -12,9 +12,13 @@ tags:
   - block
 dependencies:
   - "{{external}}.beacon_api_eth_v1_events_block_gossip"
-  - "{{external}}.beacon_api_eth_v1_events_block"
   - "{{external}}.beacon_api_eth_v1_events_head"
-  - "{{external}}.libp2p_gossipsub_beacon_block"
+  # The libp2p pipeline is deployed independently of the beacon API sentries
+  # and can stop publishing (e.g. a sidecar that predates a fork's gossip
+  # changes). OR-grouping it with the block event keeps a dead gossip feed
+  # from stalling forwardfill; whichever source is fresher gates the interval.
+  - - "{{external}}.beacon_api_eth_v1_events_block"
+    - "{{external}}.libp2p_gossipsub_beacon_block"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`

--- a/models/transformations/fct_block_proposer_head.sql
+++ b/models/transformations/fct_block_proposer_head.sql
@@ -51,7 +51,7 @@ WITH proposer_duties AS (
             proposer_validator_index,
             proposer_pubkey
         FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_proposer_duty" "helpers" "from" }} FINAL
-        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 90 SECOND AND fromUnixTimestamp({{ .bounds.end }})
             AND meta_network_name = '{{ .env.NETWORK }}'
         UNION ALL
         SELECT
@@ -62,7 +62,7 @@ WITH proposer_duties AS (
             proposer_validator_index,
             proposer_pubkey
         FROM {{ index .dep "{{external}}" "canonical_beacon_proposer_duty" "helpers" "from" }} FINAL
-        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+        WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 90 SECOND AND fromUnixTimestamp({{ .bounds.end }})
             AND meta_network_name = '{{ .env.NETWORK }}'
     )
 ),
@@ -129,7 +129,7 @@ block_gossip AS (
         epoch_start_date_time,
         block as block_root
     FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_events_block_gossip" "helpers" "from" }} FINAL
-    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 90 SECOND AND fromUnixTimestamp({{ .bounds.end }})
         AND meta_network_name = '{{ .env.NETWORK }}'
 ),
 
@@ -141,7 +141,7 @@ block_events AS (
         epoch_start_date_time,
         block as block_root
     FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_events_block" "helpers" "from" }} FINAL
-    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 90 SECOND AND fromUnixTimestamp({{ .bounds.end }})
         AND meta_network_name = '{{ .env.NETWORK }}'
 ),
 
@@ -154,7 +154,7 @@ gossipsub_blocks AS (
         block as block_root,
         proposer_index
     FROM {{ index .dep "{{external}}" "libp2p_gossipsub_beacon_block" "helpers" "from" }} FINAL
-    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 90 SECOND AND fromUnixTimestamp({{ .bounds.end }})
         AND meta_network_name = '{{ .env.NETWORK }}'
 ),
 

--- a/models/transformations/fct_block_proposer_head.sql
+++ b/models/transformations/fct_block_proposer_head.sql
@@ -14,10 +14,14 @@ tags:
   - head
 dependencies:
   - "{{external}}.beacon_api_eth_v1_events_block_gossip"
-  - "{{external}}.beacon_api_eth_v1_events_block"
   - - "{{external}}.beacon_api_eth_v1_proposer_duty"
     - "{{external}}.canonical_beacon_proposer_duty"
-  - "{{external}}.libp2p_gossipsub_beacon_block"
+  # The libp2p pipeline is deployed independently of the beacon API sentries
+  # and can stop publishing (e.g. a sidecar that predates a fork's gossip
+  # changes). OR-grouping it with the block event keeps a dead gossip feed
+  # from stalling forwardfill; whichever source is fresher gates the interval.
+  - - "{{external}}.beacon_api_eth_v1_events_block"
+    - "{{external}}.libp2p_gossipsub_beacon_block"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`


### PR DESCRIPTION
Moves `libp2p_gossipsub_beacon_block` into an OR-group with `beacon_api_eth_v1_events_block` in `fct_block_first_seen_by_node` and `fct_block_proposer_head`, so a stopped libp2p feed no longer stalls forwardfill. Both models froze on glamsterdam-devnet-7 when the gossip pipeline stopped publishing at gloas activation, while the beacon API sentries kept flowing.

Also adds `release/**` to the docker publish workflow branches. Per-devnet release branches (`release/glamsterdam-devnet-7`) get persistent image tags like `release-glamsterdam-devnet-7`, mirroring xatu's convention — the branch carrying the gloas ePBS models can then be pinned by devnet deployments without shipping those models to mainnet.