### PR TITLE
feat(fct_block_head): gloas payload hash from execution_payload events

### DIFF
--- a/models/external/beacon_api_eth_v1_events_execution_payload.sql
+++ b/models/external/beacon_api_eth_v1_events_execution_payload.sql
@@ -1,0 +1,32 @@
+---
+table: beacon_api_eth_v1_events_execution_payload
+cache:
+  incremental_scan_interval: 5s
+  full_scan_interval: 24h
+interval:
+  type: slot
+lag: 12
+---
+SELECT
+    {{ if .cache.is_incremental_scan }}
+      '{{ .cache.previous_min }}' as min,
+    {{ else }}
+      toUnixTimestamp(min(slot_start_date_time)) as min,
+    {{ end }}
+    toUnixTimestamp(max(slot_start_date_time)) as max
+FROM {{ .self.helpers.from }}
+WHERE 
+    meta_network_name = '{{ .env.NETWORK }}'
+
+    -- previous_max if incremental scan and is set, otherwise default/env
+    {{- $ts := default "0" .env.EXTERNAL_MODEL_MIN_TIMESTAMP -}}
+    {{- if .cache.is_incremental_scan -}}
+      {{- if .cache.previous_max -}}
+        {{- $ts = .cache.previous_max -}}
+      {{- end -}}
+    {{- end }}
+    AND slot_start_date_time >= fromUnixTimestamp({{ $ts }})
+    {{- if .cache.is_incremental_scan }}
+      AND slot_start_date_time <= fromUnixTimestamp({{ $ts }}) + {{ default "100000" .env.EXTERNAL_MODEL_SCAN_SIZE_TIMESTAMP }}
+    {{- end }}
+

--- a/models/transformations/fct_block_head.sql
+++ b/models/transformations/fct_block_head.sql
@@ -14,16 +14,36 @@ tags:
   - head
 dependencies:
   - "{{external}}.beacon_api_eth_v2_beacon_block"
+  # Gloas payload-hash source. OR-grouped with the beacon block table so
+  # networks where the execution_payload events table is empty or absent
+  # schedule unaffected.
+  - - "{{external}}.beacon_api_eth_v1_events_execution_payload"
+    - "{{external}}.beacon_api_eth_v2_beacon_block"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`
+WITH
+-- Gloas (ePBS): the beacon block no longer embeds the execution payload, so
+-- its execution_payload_block_hash is empty in the block table. The
+-- execution_payload SSE events map each revealed payload's block hash to its
+-- beacon block root. Empty on pre-gloas networks, where it contributes nothing.
+payload_events AS (
+    SELECT
+        block_root,
+        any(block_hash) AS payload_block_hash
+    FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_events_execution_payload" "helpers" "from" }}
+    WHERE meta_network_name = '{{ .env.NETWORK }}'
+        AND slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+        AND block_hash != ''
+    GROUP BY block_root
+)
 SELECT
     fromUnixTimestamp({{ .task.start }}) as updated_date_time,
     argMax(slot, updated_date_time) AS slot,
     slot_start_date_time,
     argMax(epoch, updated_date_time) AS epoch,
     argMax(epoch_start_date_time, updated_date_time) AS epoch_start_date_time,
-    block_root,
+    bb.block_root AS block_root,
     argMax(block_version, updated_date_time) AS block_version,
     argMax(block_total_bytes, updated_date_time) AS block_total_bytes,
     argMax(block_total_bytes_compressed, updated_date_time) AS block_total_bytes_compressed,
@@ -32,7 +52,9 @@ SELECT
     argMax(proposer_index, updated_date_time) AS proposer_index,
     argMax(eth1_data_block_hash, updated_date_time) AS eth1_data_block_hash,
     argMax(eth1_data_deposit_root, updated_date_time) AS eth1_data_deposit_root,
-    argMax(execution_payload_block_hash, updated_date_time) AS execution_payload_block_hash,
+    -- Pre-gloas blocks carry their payload hash. Gloas blocks fall back to
+    -- the payload observed for their block root on the SSE layer
+    coalesce(nullif(argMax(execution_payload_block_hash, updated_date_time), ''), any(pe.payload_block_hash), '') AS execution_payload_block_hash,
     argMax(execution_payload_block_number, updated_date_time) AS execution_payload_block_number,
     argMax(execution_payload_fee_recipient, updated_date_time) AS execution_payload_fee_recipient,
     argMax(execution_payload_base_fee_per_gas, updated_date_time) AS execution_payload_base_fee_per_gas,
@@ -45,7 +67,8 @@ SELECT
     argMax(execution_payload_transactions_count, updated_date_time) AS execution_payload_transactions_count,
     argMax(execution_payload_transactions_total_bytes, updated_date_time) AS execution_payload_transactions_total_bytes,
     argMax(execution_payload_transactions_total_bytes_compressed, updated_date_time) AS execution_payload_transactions_total_bytes_compressed
-FROM {{ index .dep "{{external}}" "beacon_api_eth_v2_beacon_block" "helpers" "from" }} FINAL
+FROM {{ index .dep "{{external}}" "beacon_api_eth_v2_beacon_block" "helpers" "from" }} AS bb FINAL
+GLOBAL LEFT JOIN payload_events pe ON bb.block_root = pe.block_root
 WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
     AND meta_network_name = '{{ .env.NETWORK }}'
 GROUP BY slot_start_date_time, block_root

--- a/models/transformations/int_engine_new_payload.sql
+++ b/models/transformations/int_engine_new_payload.sql
@@ -15,29 +15,30 @@ dependencies:
   - - "{{external}}.execution_engine_new_payload"
     - "{{external}}.consensus_engine_api_new_payload"
   - "{{transformation}}.fct_block_head"
+  # Gloas payload correlation source. OR-grouped with the beacon block table
+  # (already required transitively via fct_block_head) so networks where the
+  # execution_payload events table is empty or absent schedule unaffected.
+  - - "{{external}}.beacon_api_eth_v1_events_execution_payload"
+    - "{{external}}.beacon_api_eth_v2_beacon_block"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`
 WITH
-{{ if .env.GLOAS_PAYLOAD_EVENTS_DATABASE }}
 -- Gloas (ePBS): the beacon block no longer embeds the execution payload, so
--- fct_block_head carries no execution_payload_block_hash. The execution_payload
--- SSE events map each revealed payload's block hash to its beacon block root.
--- Referenced via EXTERNAL_CLUSTER instead of a declared dependency because the
--- table only exists on networks running gloas-era xatu; deployments opt in by
--- setting GLOAS_PAYLOAD_EVENTS_DATABASE to the raw database holding the table.
+-- fct_block_head carries no execution_payload_block_hash there. The
+-- execution_payload SSE events map each revealed payload's block hash to its
+-- beacon block root. Empty on pre-gloas networks, where it contributes nothing.
 payload_events AS (
     SELECT
         block_root,
         any(block_hash) AS payload_block_hash
-    FROM cluster('{{ .env.EXTERNAL_CLUSTER }}', `{{ .env.GLOAS_PAYLOAD_EVENTS_DATABASE }}`.`beacon_api_eth_v1_events_execution_payload{{ .clickhouse.local_suffix }}`)
+    FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_events_execution_payload" "helpers" "from" }}
     WHERE meta_network_name = '{{ .env.NETWORK }}'
         AND slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 5 MINUTE
             AND fromUnixTimestamp({{ .bounds.end }}) + INTERVAL 5 MINUTE
         AND block_hash != ''
     GROUP BY block_root
 ),
-{{ end }}
 -- Get slot context and block metadata from fct_block_head
 -- This provides CL context (slot, epoch, block_root, proposer_index) that execution_engine lacks
 -- Join on execution_payload_block_hash to correlate EL block hash with CL slot
@@ -50,20 +51,14 @@ block_context AS (
         bh.block_root AS block_root,
         bh.parent_root AS parent_root,
         bh.proposer_index AS proposer_index,
-{{ if .env.GLOAS_PAYLOAD_EVENTS_DATABASE }}
         -- Pre-gloas blocks carry their payload hash; gloas blocks fall back to
         -- the payload observed for their block root on the SSE layer
         coalesce(nullif(bh.execution_payload_block_hash, ''), nullif(pe.payload_block_hash, '')) AS execution_payload_block_hash,
-{{ else }}
-        bh.execution_payload_block_hash AS execution_payload_block_hash,
-{{ end }}
         bh.block_total_bytes AS block_total_bytes,
         bh.block_total_bytes_compressed AS block_total_bytes_compressed,
         bh.block_version AS block_version
     FROM {{ index .dep "{{transformation}}" "fct_block_head" "helpers" "from" }} AS bh FINAL
-{{ if .env.GLOAS_PAYLOAD_EVENTS_DATABASE }}
     GLOBAL LEFT JOIN payload_events pe ON bh.block_root = pe.block_root
-{{ end }}
     -- Use wider window to ensure we catch all blocks that might match engine events
     -- Engine events use event_date_time which may differ from slot_start_date_time
     WHERE bh.slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 5 MINUTE

--- a/models/transformations/int_engine_new_payload.sql
+++ b/models/transformations/int_engine_new_payload.sql
@@ -19,26 +19,54 @@ dependencies:
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`
 WITH
+{{ if .env.GLOAS_PAYLOAD_EVENTS_DATABASE }}
+-- Gloas (ePBS): the beacon block no longer embeds the execution payload, so
+-- fct_block_head carries no execution_payload_block_hash. The execution_payload
+-- SSE events map each revealed payload's block hash to its beacon block root.
+-- Referenced via EXTERNAL_CLUSTER instead of a declared dependency because the
+-- table only exists on networks running gloas-era xatu; deployments opt in by
+-- setting GLOAS_PAYLOAD_EVENTS_DATABASE to the raw database holding the table.
+payload_events AS (
+    SELECT
+        block_root,
+        any(block_hash) AS payload_block_hash
+    FROM cluster('{{ .env.EXTERNAL_CLUSTER }}', `{{ .env.GLOAS_PAYLOAD_EVENTS_DATABASE }}`.`beacon_api_eth_v1_events_execution_payload{{ .clickhouse.local_suffix }}`)
+    WHERE meta_network_name = '{{ .env.NETWORK }}'
+        AND slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 5 MINUTE
+            AND fromUnixTimestamp({{ .bounds.end }}) + INTERVAL 5 MINUTE
+        AND block_hash != ''
+    GROUP BY block_root
+),
+{{ end }}
 -- Get slot context and block metadata from fct_block_head
 -- This provides CL context (slot, epoch, block_root, proposer_index) that execution_engine lacks
 -- Join on execution_payload_block_hash to correlate EL block hash with CL slot
 block_context AS (
     SELECT
-        slot,
-        slot_start_date_time,
-        epoch,
-        epoch_start_date_time,
-        block_root,
-        parent_root,
-        proposer_index,
-        execution_payload_block_hash,
-        block_total_bytes,
-        block_total_bytes_compressed,
-        block_version
-    FROM {{ index .dep "{{transformation}}" "fct_block_head" "helpers" "from" }} FINAL
+        bh.slot AS slot,
+        bh.slot_start_date_time AS slot_start_date_time,
+        bh.epoch AS epoch,
+        bh.epoch_start_date_time AS epoch_start_date_time,
+        bh.block_root AS block_root,
+        bh.parent_root AS parent_root,
+        bh.proposer_index AS proposer_index,
+{{ if .env.GLOAS_PAYLOAD_EVENTS_DATABASE }}
+        -- Pre-gloas blocks carry their payload hash; gloas blocks fall back to
+        -- the payload observed for their block root on the SSE layer
+        coalesce(nullif(bh.execution_payload_block_hash, ''), nullif(pe.payload_block_hash, '')) AS execution_payload_block_hash,
+{{ else }}
+        bh.execution_payload_block_hash AS execution_payload_block_hash,
+{{ end }}
+        bh.block_total_bytes AS block_total_bytes,
+        bh.block_total_bytes_compressed AS block_total_bytes_compressed,
+        bh.block_version AS block_version
+    FROM {{ index .dep "{{transformation}}" "fct_block_head" "helpers" "from" }} AS bh FINAL
+{{ if .env.GLOAS_PAYLOAD_EVENTS_DATABASE }}
+    GLOBAL LEFT JOIN payload_events pe ON bh.block_root = pe.block_root
+{{ end }}
     -- Use wider window to ensure we catch all blocks that might match engine events
     -- Engine events use event_date_time which may differ from slot_start_date_time
-    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 5 MINUTE
+    WHERE bh.slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 5 MINUTE
         AND fromUnixTimestamp({{ .bounds.end }}) + INTERVAL 5 MINUTE
         AND execution_payload_block_hash IS NOT NULL
         AND execution_payload_block_hash != ''

--- a/models/transformations/int_engine_new_payload.sql
+++ b/models/transformations/int_engine_new_payload.sql
@@ -51,7 +51,7 @@ block_context AS (
         bh.block_root AS block_root,
         bh.parent_root AS parent_root,
         bh.proposer_index AS proposer_index,
-        -- Pre-gloas blocks carry their payload hash; gloas blocks fall back to
+        -- Pre-gloas blocks carry their payload hash. Gloas blocks fall back to
         -- the payload observed for their block root on the SSE layer
         coalesce(nullif(bh.execution_payload_block_hash, ''), nullif(pe.payload_block_hash, '')) AS execution_payload_block_hash,
         bh.block_total_bytes AS block_total_bytes,

--- a/models/transformations/int_engine_new_payload.sql
+++ b/models/transformations/int_engine_new_payload.sql
@@ -15,53 +15,30 @@ dependencies:
   - - "{{external}}.execution_engine_new_payload"
     - "{{external}}.consensus_engine_api_new_payload"
   - "{{transformation}}.fct_block_head"
-  # Gloas payload correlation source. OR-grouped with the beacon block table
-  # (already required transitively via fct_block_head) so networks where the
-  # execution_payload events table is empty or absent schedule unaffected.
-  - - "{{external}}.beacon_api_eth_v1_events_execution_payload"
-    - "{{external}}.beacon_api_eth_v2_beacon_block"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`
 WITH
--- Gloas (ePBS): the beacon block no longer embeds the execution payload, so
--- fct_block_head carries no execution_payload_block_hash there. The
--- execution_payload SSE events map each revealed payload's block hash to its
--- beacon block root. Empty on pre-gloas networks, where it contributes nothing.
-payload_events AS (
-    SELECT
-        block_root,
-        any(block_hash) AS payload_block_hash
-    FROM {{ index .dep "{{external}}" "beacon_api_eth_v1_events_execution_payload" "helpers" "from" }}
-    WHERE meta_network_name = '{{ .env.NETWORK }}'
-        AND slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 5 MINUTE
-            AND fromUnixTimestamp({{ .bounds.end }}) + INTERVAL 5 MINUTE
-        AND block_hash != ''
-    GROUP BY block_root
-),
 -- Get slot context and block metadata from fct_block_head
 -- This provides CL context (slot, epoch, block_root, proposer_index) that execution_engine lacks
 -- Join on execution_payload_block_hash to correlate EL block hash with CL slot
 block_context AS (
     SELECT
-        bh.slot AS slot,
-        bh.slot_start_date_time AS slot_start_date_time,
-        bh.epoch AS epoch,
-        bh.epoch_start_date_time AS epoch_start_date_time,
-        bh.block_root AS block_root,
-        bh.parent_root AS parent_root,
-        bh.proposer_index AS proposer_index,
-        -- Pre-gloas blocks carry their payload hash. Gloas blocks fall back to
-        -- the payload observed for their block root on the SSE layer
-        coalesce(nullif(bh.execution_payload_block_hash, ''), nullif(pe.payload_block_hash, '')) AS execution_payload_block_hash,
-        bh.block_total_bytes AS block_total_bytes,
-        bh.block_total_bytes_compressed AS block_total_bytes_compressed,
-        bh.block_version AS block_version
-    FROM {{ index .dep "{{transformation}}" "fct_block_head" "helpers" "from" }} AS bh FINAL
-    GLOBAL LEFT JOIN payload_events pe ON bh.block_root = pe.block_root
+        slot,
+        slot_start_date_time,
+        epoch,
+        epoch_start_date_time,
+        block_root,
+        parent_root,
+        proposer_index,
+        execution_payload_block_hash,
+        block_total_bytes,
+        block_total_bytes_compressed,
+        block_version
+    FROM {{ index .dep "{{transformation}}" "fct_block_head" "helpers" "from" }} FINAL
     -- Use wider window to ensure we catch all blocks that might match engine events
     -- Engine events use event_date_time which may differ from slot_start_date_time
-    WHERE bh.slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 5 MINUTE
+    WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 5 MINUTE
         AND fromUnixTimestamp({{ .bounds.end }}) + INTERVAL 5 MINUTE
         AND execution_payload_block_hash IS NOT NULL
         AND execution_payload_block_hash != ''


### PR DESCRIPTION
On gloas (ePBS) networks the beacon block no longer embeds the execution payload, so `fct_block_head.execution_payload_block_hash` is empty — and every engine timing model correlates snooper events against that column, so the `int_engine_*`/`fct_engine_*` tables stayed empty on the glamsterdam devnets even with raw snooper data flowing.

**Fix at the source**: `fct_block_head` coalesces the payload hash from the `beacon_api_eth_v1_events_execution_payload` SSE events (new external model, copied verbatim from `release/glamsterdam-devnet-7`) when the block table carries none. Every consumer of the column is repaired at once — an earlier revision of this PR patched `int_engine_new_payload` instead, but the fct engine models correlate independently, so the column had to be fixed where it's produced.

- Dependency is OR-grouped with `beacon_api_eth_v2_beacon_block`, so networks where the events table is empty or absent schedule exactly as before (CBT skips empty/erroring OR-group members).
- The coalesce prefers the block's own embedded hash: pre-gloas history, gloas history, and mixed fork histories work in one query. Final `''` arm keeps the FixedString(66) column non-NULL.
- No comment semicolons — CBT's statement splitter cuts on `;` inside comments (found the hard way in prod).

Tested against live ClickHouse via panda: on devnet-7, 299/299 blocks in the last hour resolve a payload hash through the enrichment; the identical rendered INSERT parses through ClickHouse's full analysis. This change is already live on `release/glamsterdam-devnet-{6,7}` (65c3415) feeding the devnet deployments.

**Deploy sequencing for this master PR:** the events table ships with gloas-era xatu (`007_gloas_epbs_support`, on xatu release branches only today). The rendered SQL references the table unconditionally, so don't roll a master build containing this to networks whose raw DB lacks the table (mainnet/sepolia/hoodi `default`) until that xatu migration lands there.

Known follow-up (out of scope): `int_engine_get_blobs` correlates via `beacon_api_eth_v1_beacon_blob`, which is empty under PeerDAS — needs a versioned-hash mapping from another source.

https://claude.ai/code/session_01J2ShnSwGwH4iZuXXwbLgvP