### PR TITLE
fix(fct_block_payload_ptc_vote): stop labelling canonical blocks orphaned

### DIFF
--- a/.github/workflows/test-glamsterdam-devnet-7.yaml
+++ b/.github/workflows/test-glamsterdam-devnet-7.yaml
@@ -33,6 +33,10 @@ jobs:
     runs-on:
       - self-hosted-ghr
       - size-l-x64
+    env:
+      # Must match the Checkout Xatu ref below. Passed as --xatu-ref because the
+      # CLI defaults to master and force-resets the existing checkout to it.
+      XATU_REF: ${{ github.event.inputs.xatu_ref || 'release/glamsterdam-devnet-7' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up env
@@ -42,7 +46,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ethpandaops/xatu
-          ref: ${{ github.event.inputs.xatu_ref || 'release/glamsterdam-devnet-7' }}
+          ref: ${{ env.XATU_REF }}
           path: xatu
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
@@ -58,15 +62,15 @@ jobs:
         run: mkdir -p .parquet_cache
       - name: Start infrastructure
         id: start-infra
-        run: ./bin/xatu-cbt infra start
+        run: ./bin/xatu-cbt infra start --xatu-ref "$XATU_REF"
       - name: Run glamsterdam-devnet-7 tests (full suite)
         if: needs.detect.outputs.models == 'all'
-        run: ./bin/xatu-cbt test all --network glamsterdam-devnet-7 --verbose
+        run: ./bin/xatu-cbt test all --network glamsterdam-devnet-7 --verbose --xatu-ref "$XATU_REF"
       - name: Run glamsterdam-devnet-7 tests (impacted only)
         if: needs.detect.outputs.models != 'all'
         run: |
           echo "Running impacted models: ${{ needs.detect.outputs.models }}"
-          ./bin/xatu-cbt test models ${{ needs.detect.outputs.models }} --network glamsterdam-devnet-7 --verbose
+          ./bin/xatu-cbt test models ${{ needs.detect.outputs.models }} --network glamsterdam-devnet-7 --verbose --xatu-ref "$XATU_REF"
       - name: Stop infrastructure
         if: always() && steps.start-infra.outcome != 'skipped'
         run: ./bin/xatu-cbt infra stop

--- a/.github/workflows/test-mainnet.yaml
+++ b/.github/workflows/test-mainnet.yaml
@@ -33,6 +33,10 @@ jobs:
     runs-on:
       - self-hosted-ghr
       - size-l-x64
+    env:
+      # Must match the Checkout Xatu ref below. Passed as --xatu-ref because the
+      # CLI defaults to master and force-resets the existing checkout to it.
+      XATU_REF: ${{ github.event.inputs.xatu_ref || 'master' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up env
@@ -42,7 +46,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ethpandaops/xatu
-          ref: ${{ github.event.inputs.xatu_ref || 'master' }}
+          ref: ${{ env.XATU_REF }}
           path: xatu
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
@@ -58,7 +62,7 @@ jobs:
         run: mkdir -p .parquet_cache
       - name: Start infrastructure
         id: start-infra
-        run: ./bin/xatu-cbt infra start
+        run: ./bin/xatu-cbt infra start --xatu-ref "$XATU_REF"
       - name: Run mainnet tests (full suite)
         if: needs.detect.outputs.models == 'all'
         # 2 shards do ~2x the per-test work (ON CLUSTER DDL + distributed inserts +
@@ -67,12 +71,12 @@ jobs:
         # the heavy libp2p_gossipsub_beacon_attestation parquet load lose its resource race and
         # blow the 5m QueryTimeout, while 10-wide loads it fine. DDL pool_size=4 keeps the
         # up-front clone phase fast regardless.
-        run: ./bin/xatu-cbt test all --network mainnet --verbose --concurrency 10 --timeout 60m
+        run: ./bin/xatu-cbt test all --network mainnet --verbose --concurrency 10 --timeout 60m --xatu-ref "$XATU_REF"
       - name: Run mainnet tests (impacted only)
         if: needs.detect.outputs.models != 'all'
         run: |
           echo "Running impacted models: ${{ needs.detect.outputs.models }}"
-          ./bin/xatu-cbt test models ${{ needs.detect.outputs.models }} --network mainnet --verbose --concurrency 10
+          ./bin/xatu-cbt test models ${{ needs.detect.outputs.models }} --network mainnet --verbose --concurrency 10 --xatu-ref "$XATU_REF"
       - name: Stop infrastructure
         if: always() && steps.start-infra.outcome != 'skipped'
         run: ./bin/xatu-cbt infra stop

--- a/.github/workflows/test-sepolia.yaml
+++ b/.github/workflows/test-sepolia.yaml
@@ -33,6 +33,10 @@ jobs:
     runs-on:
       - self-hosted-ghr
       - size-l-x64
+    env:
+      # Must match the Checkout Xatu ref below. Passed as --xatu-ref because the
+      # CLI defaults to master and force-resets the existing checkout to it.
+      XATU_REF: ${{ github.event.inputs.xatu_ref || 'master' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up env
@@ -42,7 +46,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ethpandaops/xatu
-          ref: ${{ github.event.inputs.xatu_ref || 'master' }}
+          ref: ${{ env.XATU_REF }}
           path: xatu
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
@@ -58,15 +62,15 @@ jobs:
         run: mkdir -p .parquet_cache
       - name: Start infrastructure
         id: start-infra
-        run: ./bin/xatu-cbt infra start
+        run: ./bin/xatu-cbt infra start --xatu-ref "$XATU_REF"
       - name: Run sepolia tests (full suite)
         if: needs.detect.outputs.models == 'all'
-        run: ./bin/xatu-cbt test all --network sepolia --verbose
+        run: ./bin/xatu-cbt test all --network sepolia --verbose --xatu-ref "$XATU_REF"
       - name: Run sepolia tests (impacted only)
         if: needs.detect.outputs.models != 'all'
         run: |
           echo "Running impacted models: ${{ needs.detect.outputs.models }}"
-          ./bin/xatu-cbt test models ${{ needs.detect.outputs.models }} --network sepolia --verbose
+          ./bin/xatu-cbt test models ${{ needs.detect.outputs.models }} --network sepolia --verbose --xatu-ref "$XATU_REF"
       - name: Stop infrastructure
         if: always() && steps.start-infra.outcome != 'skipped'
         run: ./bin/xatu-cbt infra stop

--- a/migrations/110_ptc_vote_no_included_votes_comments.down.sql
+++ b/migrations/110_ptc_vote_no_included_votes_comments.down.sql
@@ -1,0 +1,37 @@
+-- Restore the column comments as created in 103_block_payload_ptc_vote.up.sql.
+
+ALTER TABLE int_block_payload_ptc_vote_canonical_local ON CLUSTER '{cluster}'
+    COMMENT COLUMN `block_version` 'The beacon block version of the containing block';
+
+ALTER TABLE int_block_payload_ptc_vote_canonical_local ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_slot` 'Slot of the canonical block that included the payload attestations';
+
+ALTER TABLE int_block_payload_ptc_vote_canonical_local ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_block_root` 'Root of the canonical block that included the payload attestations';
+
+ALTER TABLE int_block_payload_ptc_vote_canonical ON CLUSTER '{cluster}'
+    COMMENT COLUMN `block_version` 'The beacon block version of the containing block';
+
+ALTER TABLE int_block_payload_ptc_vote_canonical ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_slot` 'Slot of the canonical block that included the payload attestations';
+
+ALTER TABLE int_block_payload_ptc_vote_canonical ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_block_root` 'Root of the canonical block that included the payload attestations';
+
+ALTER TABLE fct_block_payload_ptc_vote_local ON CLUSTER '{cluster}'
+    COMMENT COLUMN `block_version` 'The beacon block version of the containing block, empty for orphaned rows';
+
+ALTER TABLE fct_block_payload_ptc_vote_local ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_slot` 'Slot of the canonical block that included the payload attestations, null for orphaned rows';
+
+ALTER TABLE fct_block_payload_ptc_vote_local ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_block_root` 'Root of the canonical block that included the payload attestations, null for orphaned rows';
+
+ALTER TABLE fct_block_payload_ptc_vote ON CLUSTER '{cluster}'
+    COMMENT COLUMN `block_version` 'The beacon block version of the containing block, empty for orphaned rows';
+
+ALTER TABLE fct_block_payload_ptc_vote ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_slot` 'Slot of the canonical block that included the payload attestations, null for orphaned rows';
+
+ALTER TABLE fct_block_payload_ptc_vote ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_block_root` 'Root of the canonical block that included the payload attestations, null for orphaned rows';

--- a/migrations/110_ptc_vote_no_included_votes_comments.up.sql
+++ b/migrations/110_ptc_vote_no_included_votes_comments.up.sql
@@ -1,0 +1,47 @@
+-- Clarify that a canonical block can carry zero PTC votes.
+--
+-- int_block_payload_ptc_vote_canonical now emits one row per canonical block
+-- regardless of whether its PTC votes reached the chain: when slot N+1 is
+-- missed the votes for slot N are never included, so the row carries zero
+-- counts and empty included_in_*. The original comments only described the
+-- orphaned case and now read as if those columns are always populated.
+--
+-- Comments live on both the _local and the Distributed table, so both are
+-- updated. The Distributed table copies the column definitions at creation
+-- time and does not inherit later changes to the local one.
+
+ALTER TABLE int_block_payload_ptc_vote_canonical_local ON CLUSTER '{cluster}'
+    COMMENT COLUMN `block_version` 'The beacon block version of the containing block, empty when no votes were included';
+
+ALTER TABLE int_block_payload_ptc_vote_canonical_local ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_slot` 'Slot of the canonical block that included the payload attestations, 0 when no votes were included';
+
+ALTER TABLE int_block_payload_ptc_vote_canonical_local ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_block_root` 'Root of the canonical block that included the payload attestations, empty when no votes were included';
+
+ALTER TABLE int_block_payload_ptc_vote_canonical ON CLUSTER '{cluster}'
+    COMMENT COLUMN `block_version` 'The beacon block version of the containing block, empty when no votes were included';
+
+ALTER TABLE int_block_payload_ptc_vote_canonical ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_slot` 'Slot of the canonical block that included the payload attestations, 0 when no votes were included';
+
+ALTER TABLE int_block_payload_ptc_vote_canonical ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_block_root` 'Root of the canonical block that included the payload attestations, empty when no votes were included';
+
+ALTER TABLE fct_block_payload_ptc_vote_local ON CLUSTER '{cluster}'
+    COMMENT COLUMN `block_version` 'The beacon block version of the containing block, empty for orphaned rows and for canonical blocks whose votes were never included';
+
+ALTER TABLE fct_block_payload_ptc_vote_local ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_slot` 'Slot of the canonical block that included the payload attestations, null for orphaned rows and for canonical blocks whose votes were never included';
+
+ALTER TABLE fct_block_payload_ptc_vote_local ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_block_root` 'Root of the canonical block that included the payload attestations, null for orphaned rows and for canonical blocks whose votes were never included';
+
+ALTER TABLE fct_block_payload_ptc_vote ON CLUSTER '{cluster}'
+    COMMENT COLUMN `block_version` 'The beacon block version of the containing block, empty for orphaned rows and for canonical blocks whose votes were never included';
+
+ALTER TABLE fct_block_payload_ptc_vote ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_slot` 'Slot of the canonical block that included the payload attestations, null for orphaned rows and for canonical blocks whose votes were never included';
+
+ALTER TABLE fct_block_payload_ptc_vote ON CLUSTER '{cluster}'
+    COMMENT COLUMN `included_in_block_root` 'Root of the canonical block that included the payload attestations, null for orphaned rows and for canonical blocks whose votes were never included';

--- a/models/transformations/fct_block_payload_ptc_vote.sql
+++ b/models/transformations/fct_block_payload_ptc_vote.sql
@@ -22,6 +22,11 @@ INSERT INTO
 -- Gloas (ePBS): per-block PTC verdict. Canonical rows carry the on-chain
 -- aggregated vote counts, while blocks only seen on the live stream are tagged
 -- orphaned with the stream-observed counts.
+--
+-- The canonical side holds every canonical block, including those whose votes
+-- never reached the chain because slot N+1 was missed. Such rows report zero
+-- counts and null included_in_*, so status stays 'canonical' and only blocks
+-- genuinely absent from the chain fall through to the orphaned branch.
 WITH canonical_votes AS (
     SELECT
         slot,
@@ -30,8 +35,8 @@ WITH canonical_votes AS (
         epoch_start_date_time,
         block_root,
         block_version,
-        included_in_slot,
-        included_in_block_root,
+        nullIf(included_in_slot, 0) AS included_in_slot,
+        nullIf(included_in_block_root, '') AS included_in_block_root,
         ptc_validators,
         payload_present_votes,
         blob_data_available_votes,

--- a/models/transformations/int_block_payload_ptc_vote_canonical.sql
+++ b/models/transformations/int_block_payload_ptc_vote_canonical.sql
@@ -26,6 +26,12 @@ INSERT INTO
 -- past the interval end while output rows stay keyed inside the interval by
 -- the attested block's own slot. Aggregates are packed per vote combination
 -- with disjoint bitvectors, so attesting_validator_count sums cleanly.
+--
+-- Emits one row per canonical block, votes or not: when slot N+1 is missed the
+-- PTC votes for slot N never reach the chain, but slot N is still canonical.
+-- Those rows carry zero counts and empty included_in_*, which is what lets
+-- downstream models treat "absent from this table" as "not on the canonical
+-- chain" rather than "no votes were included".
 WITH included_attestations AS (
     SELECT
         slot AS included_in_slot,
@@ -63,6 +69,6 @@ SELECT
     SUM(a.attesting_validator_count) AS ptc_validators,
     sumIf(a.attesting_validator_count, a.payload_present) AS payload_present_votes,
     sumIf(a.attesting_validator_count, a.blob_data_available) AS blob_data_available_votes
-FROM included_attestations a
-GLOBAL INNER JOIN attested_blocks b ON a.beacon_block_root = b.block_root
+FROM attested_blocks b
+GLOBAL LEFT JOIN included_attestations a ON a.beacon_block_root = b.block_root
 GROUP BY b.slot, b.slot_start_date_time, b.epoch, b.epoch_start_date_time, b.block_root

--- a/models/transformations/int_block_payload_ptc_vote_canonical.sql
+++ b/models/transformations/int_block_payload_ptc_vote_canonical.sql
@@ -72,3 +72,5 @@ SELECT
 FROM attested_blocks b
 GLOBAL LEFT JOIN included_attestations a ON a.beacon_block_root = b.block_root
 GROUP BY b.slot, b.slot_start_date_time, b.epoch, b.epoch_start_date_time, b.block_root
+-- Unmatched LEFT JOIN rows must zero-fill so the sums land as 0, not NULL
+SETTINGS join_use_nulls = 0

--- a/tests/glamsterdam-devnet-7/models/fct_block_payload_ptc_vote.yaml
+++ b/tests/glamsterdam-devnet-7/models/fct_block_payload_ptc_vote.yaml
@@ -109,9 +109,9 @@ assertions:
           value: 0
     - name: Blocks on the canonical chain are never labelled orphaned
       sql: |
-        SELECT COUNT(*) AS bad_rows FROM fct_block_payload_ptc_vote FINAL v
+        SELECT COUNT(*) AS bad_rows FROM fct_block_payload_ptc_vote AS v FINAL
         WHERE v.status = 'orphaned'
-          AND v.block_root IN (
+          AND v.block_root GLOBAL IN (
             SELECT block_root FROM canonical_beacon_block
           )
       assertions:

--- a/tests/glamsterdam-devnet-7/models/fct_block_payload_ptc_vote.yaml
+++ b/tests/glamsterdam-devnet-7/models/fct_block_payload_ptc_vote.yaml
@@ -90,10 +90,30 @@ assertions:
         - type: equals
           column: bad_rows
           value: 0
-    - name: Canonical rows must carry an included_in_slot value
+    - name: Canonical rows whose votes reached the chain carry an included_in_slot value
       sql: |
         SELECT COUNT(*) AS bad_rows FROM fct_block_payload_ptc_vote FINAL
-        WHERE status = 'canonical' AND included_in_slot IS NULL
+        WHERE status = 'canonical' AND ptc_validators > 0 AND included_in_slot IS NULL
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Orphaned rows never carry an inclusion reference
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_block_payload_ptc_vote FINAL
+        WHERE status = 'orphaned'
+          AND (included_in_slot IS NOT NULL OR included_in_block_root IS NOT NULL)
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Blocks on the canonical chain are never labelled orphaned
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM fct_block_payload_ptc_vote FINAL v
+        WHERE v.status = 'orphaned'
+          AND v.block_root IN (
+            SELECT block_root FROM canonical_beacon_block
+          )
       assertions:
         - type: equals
           column: bad_rows

--- a/tests/glamsterdam-devnet-7/models/fct_block_payload_ptc_vote.yaml
+++ b/tests/glamsterdam-devnet-7/models/fct_block_payload_ptc_vote.yaml
@@ -108,11 +108,13 @@ assertions:
           column: bad_rows
           value: 0
     - name: Blocks on the canonical chain are never labelled orphaned
+      # int_block_canonical rather than canonical_beacon_block: assertions run
+      # against the CBT cluster only, where external tables do not exist.
       sql: |
         SELECT COUNT(*) AS bad_rows FROM fct_block_payload_ptc_vote AS v FINAL
         WHERE v.status = 'orphaned'
           AND v.block_root GLOBAL IN (
-            SELECT block_root FROM canonical_beacon_block
+            SELECT block_root FROM int_block_canonical
           )
       assertions:
         - type: equals

--- a/tests/glamsterdam-devnet-7/models/int_block_payload_ptc_vote_canonical.yaml
+++ b/tests/glamsterdam-devnet-7/models/int_block_payload_ptc_vote_canonical.yaml
@@ -15,10 +15,18 @@ assertions:
         - type: greater_than
           column: row_count
           value: 0
-    - name: No non-positive ptc_validators totals
+    - name: Blocks whose votes were included carry a positive ptc_validators total
       sql: |
         SELECT COUNT(*) AS bad_rows FROM int_block_payload_ptc_vote_canonical FINAL
-        WHERE ptc_validators <= 0
+        WHERE included_in_slot != 0 AND ptc_validators <= 0
+      assertions:
+        - type: equals
+          column: bad_rows
+          value: 0
+    - name: Zero-vote rows and missing inclusion always agree
+      sql: |
+        SELECT COUNT(*) AS bad_rows FROM int_block_payload_ptc_vote_canonical FINAL
+        WHERE (ptc_validators = 0) != (included_in_slot = 0)
       assertions:
         - type: equals
           column: bad_rows
@@ -58,7 +66,7 @@ assertions:
     - name: Attested slot is always earlier than the containing (included) slot
       sql: |
         SELECT COUNT(*) AS bad_rows FROM int_block_payload_ptc_vote_canonical FINAL
-        WHERE included_in_slot <= slot
+        WHERE included_in_slot != 0 AND included_in_slot <= slot
       assertions:
         - type: equals
           column: bad_rows


### PR DESCRIPTION
## Problem

`int_block_payload_ptc_vote_canonical` built its rows with a `GLOBAL INNER JOIN` from included payload attestations to canonical blocks, so a canonical block whose PTC votes never reached the chain produced **no row at all**. `fct_block_payload_ptc_vote` then anti-joined against that table and tagged every miss `'orphaned'` — conflating *"no votes were included"* with *"not on the canonical chain"*.

PTC votes for slot N are included in slot N+1, so whenever N+1 is missed, the votes for N are never included and the block is mislabelled.

## Impact on glamsterdam-devnet-7

Verified across **every** affected row, not a sample:

| | Count |
|---|---|
| Rows labelled `orphaned` | 2,658 |
| ...actually on the canonical chain | **2,627 (98.8%)** |
| ...genuine orphans | 31 |

Cross-checked `fct_block_payload_ptc_vote` against `canonical_beacon_block` by `block_root` over the full slot range.

Of the 2,627, all but one are explained by "slot N+1 was missed". The exception is **slot 7714**: canonical, slot 7715 exists and is canonical, yet there are no payload attestations anywhere in slots 7714–7716. It sits deep in history, so it is not a leading-edge artifact — it looks like a gap in `canonical_beacon_block_payload_attestation`. Worth knowing that "absent from the int table" will not *always* mean "N+1 was missed".

## Fix

Drive the int model from `attested_blocks` with a `LEFT JOIN` so every canonical block gets a row, with zero counts when no votes were included, and map the empty inclusion fields to NULL in fct via `nullIf`.

The anti-join is **unchanged** and becomes correct on its own, since absence from the canonical table now means "not on the canonical chain".

Verified against production ClickHouse (26.2.5.45):

- **LEFT JOIN zero-fill** — `join_use_nulls = 0` on `clickhouse-refined`, so an unmatched row yields `0`, not NULL, and `nullIf(0, 0)` → NULL. This is now pinned in the int model with `SETTINGS join_use_nulls = 0` rather than relying on the server default — a profile with `join_use_nulls = 1` would NULL the sums and break the insert into non-nullable columns.
- **Column types** are plain `UInt32` / `String`, so `nullIf(x, 0)` and `nullIf(x, '')` behave as intended.
- **Row coverage** — a gap of 108 between canonical blocks and int vote rows in the sampled range; after the fix the int model emits all of them.

## ⚠️ This changes hourly delivery rates

An earlier revision of this description claimed the downstream `fct_block_payload_status_hourly` filter on `ptc_validators > 0` meant hourly rates were unaffected. **That was wrong.**

It holds only for canonical blocks that previously had *no row at all*. The 2,627 mislabelled blocks **already have rows**, carrying real head-observed vote counts (mean 69, median 67, every one > 0). `fct_block_payload_status_hourly` has no `status` filter, so it counts them today. After this fix they become `ptc_validators = 0` and are filtered out:

| | Before | After |
|---|---|---|
| Rows feeding the hourly model | 35,426 | 32,799 |
| Reported delivery rate | 95.7% | **96.7%** |

- **7.42%** of the denominator disappears (2,627 rows)
- The removal is **biased** — those rows are 83.1% `delivered` vs 95.7% for the population — so the rate rises about **+1.0pp**
- 182,544 stream-observed votes become zero in this table

**This is the correct behavior, but it is a visible shift.** A block whose PTC verdict never reached the chain has no on-chain verdict, and `fct_block_payload_status_hourly` measures on-chain verdicts — excluding it is the honest handling of missing data. Anyone watching a delivery-rate dashboard will see the step change.

### Why not coalesce the head-observed counts in?

Considered and rejected:

- **Nothing is lost.** All 2,627 blocks remain in `fct_block_payload_ptc_vote_head` (verified: 100% retained), keyed identically on `(slot_start_date_time, block_root)`. Stream counts stay one join away.
- **They are not the same quantity.** On-chain `ptc_validators` sums `attesting_validator_count` over aggregates that reached consensus; head `ptc_validators_seen` counts distinct validators the sentries observed — a sample with coverage-dependent bias. Coalescing makes one column mean two things inside `status = 'canonical'` with no way to tell which, and the hourly majority test `payload_present_votes * 2 >= ptc_validators` would silently inherit whichever source filled the row.
- **The 83.1% figure is unexplained.** It may be real, or a sampling artifact of partial sentry coverage. Coalescing would bake that open question into the headline metric.

The zero rows stay distinguishable: `ptc_validators = 0` co-occurs with `included_in_slot IS NULL`.

## Backfill required

Existing rows do not self-correct. The `ReplacingMergeTree` key is `(slot_start_date_time, block_root)`, so a backfill over the affected range overwrites them in place. The bug is still actively accumulating.

## Schema comments

New migration `110_ptc_vote_no_included_votes_comments` updates twelve column comments — `block_version` and `included_in_*` on both the int and fct tables, on the `_local` tables **and** their `Distributed` wrappers — to describe the zero-vote canonical rows, not just orphaned ones. A follow-on migration rather than an edit to `migrations/103` because 103 is already applied on the live devnet database and golang-migrate never re-runs applied files.

Mechanics, verified against ClickHouse docs: `COMMENT COLUMN` is metadata-only (no mutation/part rewrite) and self-replicates on `Replicated*` engines via the Keeper log; the `Distributed` wrappers need their own `ALTER` because they copy column definitions at creation and never inherit later changes to the local table. Header comments deliberately avoid `;` — golang-migrate's `x-multi-statement` splits naively on semicolons, even inside SQL comments.

⚠️ The generated protos in `pkg/proto/clickhouse/` still carry the old comment text. `make proto` needs local ClickHouse infra plus a full DB rebuild, which does not currently work on this branch, so they will pick up the new wording on the next regeneration.

## ✅ Tests now pass in CI (after fixing the workflow itself)

**Both model tests now execute and pass in CI**: 11/11 assertions on the int model, 13/13 on the fct model ([run 29717494881](https://github.com/ethpandaops/xatu-cbt/actions/runs/29717494881)). An earlier revision of this section warned the tests were unexecutable — that was true, and the reason turned out to be a bug in the CI workflow, not just a local limitation:

The workflow checks out `ethpandaops/xatu` at `release/glamsterdam-devnet-7` (which has `007_gloas_epbs_support` and the payload attestation tables), but `xatu-cbt infra start` / `xatu-cbt test` default `--xatu-ref` to `master` and, on finding an existing checkout, force-reset it with `git checkout -f -B master FETCH_HEAD` — silently discarding the release branch. Every run then died pre-clone with `Table 'beacon_api_eth_v1_events_payload_attestation' doesn't exist` before any model SQL executed. All three test workflows now hoist the ref into job-level env and pass `--xatu-ref` explicitly; mainnet/sepolia were only surviving because their ref happens to be `master`, which also meant their `workflow_dispatch` `xatu_ref` input was silently ignored.

## Test changes

Three assertions encoded the old (incorrect) invariant and would now fail correctly, so they were rescoped to rows that actually carry an inclusion:

- `ptc_validators <= 0` (int)
- `included_in_slot <= slot` (int)
- "Canonical rows must carry an included_in_slot" (fct) — scoped to `ptc_validators > 0`

Added: zero-vote/no-inclusion consistency, orphaned rows never carrying an inclusion reference, and a regression test that no block on the canonical chain (per `int_block_canonical`) is labelled orphaned.

### Three bugs fixed in the new regression test

The regression assertion did not run at all as first written. The first two were caught against a live ClickHouse before CI; the third only surfaced on the assertion's first-ever CI execution:

1. `FROM ... FINAL v` — the alias must precede `FINAL`. Hard `Code: 62` syntax error. Corrected to `AS v FINAL`.
2. `IN (subquery)` across two `Distributed` tables — rejected with `Code: 288: Double-distributed IN/JOIN subqueries is denied (distributed_product_mode = 'deny')`. Corrected to `GLOBAL IN`, consistent with the `GLOBAL` joins used throughout these models.
3. The subquery originally read from `canonical_beacon_block` — but transformation-model assertions execute against the CBT cluster's test database only, and external tables live on the xatu cluster, so this failed with `Code: 60: Unknown table expression identifier`. Re-anchored to `int_block_canonical`: same test database, a declared dependency, and the very table that drives the canonical/orphaned split, so the invariant is unchanged (arguably stated more precisely).

Each was masked by the one before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


